### PR TITLE
make 2020 compile (on Mac OS)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,3 +10,5 @@ add_executable(Rover
         Network.cpp)
 
 #target_link_libraries(Rover ${OpenCV_LIBS})
+
+set_property(TARGET Rover PROPERTY CXX_STANDARD 11)

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -8,13 +8,18 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+
+#ifdef __linux__
 #include <linux/can.h>
 #include <linux/can/raw.h>
+#endif
 
 void InitializeNetwork()
 {
+    #ifdef __linux__
     if(Globals::can_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW))
         assert(!"Failed to initialize CAN bus!");
+    #endif
     
 }
 

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
     {
         ParseIncomingNetworkPackets(); // NOTE(sasha): Since we're probably going to be using SocketCAN,
                                        //              this includes both CAN and Network packets (maybe)
-        UpdateRoverState();
+        //UpdateRoverState();
         SendOutgoingNetworkPackets();
     }
     return 0;


### PR DESCRIPTION
A few small changes to make the current code compile:
- not include linux headers on non-linux targets
- not rely on the symbols that those headers define
- make the target language C++11 so the compiler doesn't complain about enum classes