### PR TITLE
Rover main loop now handles CAN and base station communication

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(Rover
         Globals.cpp
         Networking/Network.cpp
         Networking/CANUtils.cpp
+        Networking/ParseBaseStation.cpp
         Util.cpp
         mapping/EnvMap.cpp
         Networking/ParseCAN.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,8 @@ add_executable(Rover
         CommandLineOptions.cpp
         Globals.cpp
         Networking/Network.cpp
-	Util.cpp
+        Networking/CANUtils.cpp
+        Util.cpp
         mapping/EnvMap.cpp
         Networking/ParseCAN.cpp
         HindsightCAN/CANPacket.c
@@ -71,6 +72,7 @@ add_executable(FakeBaseStation
 
 add_executable(FakeCANBoard
   Networking/FakeCANBoard.cpp
+  Networking/CANUtils.cpp
   HindsightCAN/CANPacket.c
   HindsightCAN/CANCommon.c
   HindsightCAN/PortTemplate.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(tests
   ar/Tag.cpp
   # CAN tests
   Networking/tests.cpp
+  Networking/TestPackets.cpp
   CommandLineOptions.cpp
   Globals.cpp
   Networking/Network.cpp
@@ -73,6 +74,7 @@ add_executable(FakeBaseStation
 add_executable(FakeCANBoard
   Networking/FakeCANBoard.cpp
   Networking/CANUtils.cpp
+  Networking/TestPackets.cpp
   HindsightCAN/CANPacket.c
   HindsightCAN/CANCommon.c
   HindsightCAN/PortTemplate.c)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,4 +66,7 @@ add_executable(Server
 add_executable(TCPClient
   Networking/TCPClient.cpp)
 
+add_executable(FakeBaseStation
+  Networking/FakeBaseStation.cpp)
+
 set_property(TARGET Rover PROPERTY CXX_STANDARD 14)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,4 +69,10 @@ add_executable(TCPClient
 add_executable(FakeBaseStation
   Networking/FakeBaseStation.cpp)
 
+add_executable(FakeCANBoard
+  Networking/FakeCANBoard.cpp
+  HindsightCAN/CANPacket.c
+  HindsightCAN/CANCommon.c
+  HindsightCAN/PortTemplate.c)
+
 set_property(TARGET Rover PROPERTY CXX_STANDARD 14)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_executable(Rover
         Rover.cpp
         CommandLineOptions.cpp
         Globals.cpp
-        Network.cpp
+        Networking/Network.cpp
 	Util.cpp
         mapping/EnvMap.cpp
         Networking/ParseCAN.cpp
@@ -46,7 +46,7 @@ add_executable(tests
   Networking/tests.cpp
   CommandLineOptions.cpp
   Globals.cpp
-  Network.cpp
+  Networking/Network.cpp
   Networking/ParseCAN.cpp
   HindsightCAN/CANPacket.c
   HindsightCAN/CANCommon.c

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -9,6 +9,4 @@ CommandLineOptions Globals::opts;
 RoverState Globals::curr_state;
 std::vector<Packet> Globals::incoming_packets;
 std::vector<Packet> Globals::outgoing_packets;
-int Globals::can_fd;
-int Globals::net_fd;
 nlohmann::json Globals::status_data;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -1,6 +1,5 @@
 #include "CommandLineOptions.h"
 #include "Globals.h"
-#include "Network.h"
 #include "Networking/json.hpp"
 
 #include <vector>

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CommandLineOptions.h"
-#include "Network.h"
+#include "Networking/Network.h"
 #include "Networking/json.hpp"
 
 #include <vector>

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -21,7 +21,5 @@ namespace Globals
     extern RoverState curr_state;
     extern std::vector<Packet> incoming_packets;
     extern std::vector<Packet> outgoing_packets;
-    extern int can_fd;
-    extern int net_fd;
     extern nlohmann::json status_data;
 }

--- a/src/Network.h
+++ b/src/Network.h
@@ -4,7 +4,7 @@
 #include "Constants.h"
 #include "Networking/json.hpp"
 
-extern "C" 
+extern "C"
 {
     #include "HindsightCAN/CANPacket.h"
     #include "HindsightCAN/CANCommon.h"
@@ -25,8 +25,7 @@ struct Packet
     uint8_t payload[Constants::PACKET_PAYLOAD_SIZE];
 };
 
-void InitializeNetwork();
-void ParseIncomingNetworkPackets();
-void SendOutgoingNetworkPackets();
-void SendMissionControlStatus();
-void TestCANPackets();
+void InitializeCANSocket();
+void InitializeBaseStationSocket();
+void recvCANPacket();
+void recvBaseStationPacket();

--- a/src/Networking/CANUtils.cpp
+++ b/src/Networking/CANUtils.cpp
@@ -1,0 +1,98 @@
+#include "NetworkConstants.h"
+extern "C"
+{
+    #include "../HindsightCAN/CANPacket.h"
+}
+
+#include <net/if.h>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <aio.h>
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <aio.h>
+
+struct sockaddr_can can_addr;
+struct can_frame can_frame_;
+struct ifreq can_ifr;
+
+#include<iostream>
+
+int can_fd;
+
+void error(const char *msg) {
+  perror(msg);
+  exit(1);
+}
+
+void InitializeCANSocket()
+{
+  if((can_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+    error("Failed to initialize CAN bus!");
+  }
+
+  strcpy(can_ifr.ifr_name, "can0");
+  if (ioctl(can_fd, SIOCGIFINDEX, &can_ifr) < 0) {
+    perror("Failed to get hardware CAN interface index");
+    strcpy(can_ifr.ifr_name, "vcan0");
+    if (ioctl(can_fd, SIOCGIFINDEX, &can_ifr) < 0) {
+      // You can make a virtual CAN interface with
+      //
+      // sudo ip link add type vcan
+      // sudo ip link set dev vcan0 up
+      //
+      error("Failed to get virtual CAN interface index");
+    }
+    std::cout << "Found virtual CAN interface index." << std::endl;
+  }
+
+  can_addr.can_family = AF_CAN;
+  std::cout << "Index: " << can_ifr.ifr_ifindex << std::endl;
+  can_addr.can_ifindex = can_ifr.ifr_ifindex;
+
+  if (bind(can_fd, (struct sockaddr *)&can_addr, sizeof(can_addr)) < 0) {
+    error("Failed to bind CAN socket");
+  }
+}
+
+void SendTestCANPacket()
+{
+  can_frame_.can_id = ConstructCANID(PACKET_PRIORITY_NORMAL, DEVICE_GROUP_JETSON, DEVICE_SERIAL_JETSON);
+  can_frame_.can_dlc = 7;
+  WriteSenderSerialAndPacketID(can_frame_.data, 0x36); // 0x36 is telemetry report
+  can_frame_.data[2] = 0x01; // current
+  for(int i = 3; i < 8; i++){
+      can_frame_.data[i] = 0;
+  }
+  can_frame_.data[5] = 0x01; // 256 milliamps
+
+  if (sendto(can_fd, &can_frame_, sizeof(struct can_frame),
+        0, (struct sockaddr*)&can_addr, sizeof(can_addr)) < 0) {
+    perror("Failed to send CAN packet");
+  } else {
+    std::cout << "CAN packet sent.\n";
+  }
+}
+
+CANPacket recvCANPacket()
+{
+  CANPacket packet;
+  socklen_t len = sizeof(can_addr);
+
+  std::cout << "Waiting for CAN packet" << std::endl;
+  if (recvfrom(can_fd, &can_frame_, sizeof(struct can_frame),
+                0, (struct sockaddr*)&can_addr, &len) < 0) {
+    perror("Failed to receive CAN packet");
+  } else {
+    std::cout << "Got CAN packet" << std::endl;
+    packet.id = can_frame_.can_id;
+    for(int i = 0; i < can_frame_.can_dlc; i++){
+        packet.data[i] = can_frame_.data[i];
+    }
+  }
+  return packet;
+}

--- a/src/Networking/CANUtils.h
+++ b/src/Networking/CANUtils.h
@@ -9,6 +9,9 @@ extern "C"
 
 void InitializeCANSocket();
 void SendCANPacket(const CANPacket &packet);
-CANPacket recvCANPacket();
+
+// Returns 1 if a packet was received, 0 otherwise
+// If a packet was received, stores it at *packet.
+int recvCANPacket(CANPacket *packet);
 
 #endif

--- a/src/Networking/CANUtils.h
+++ b/src/Networking/CANUtils.h
@@ -1,0 +1,14 @@
+
+#ifndef __CAN_UTILS_H__
+#define __CAN_UTILS_H__
+
+extern "C"
+{
+    #include "../HindsightCAN/CANPacket.h"
+}
+
+void InitializeCANSocket();
+void SendTestCANPacket();
+CANPacket recvCANPacket();
+
+#endif

--- a/src/Networking/CANUtils.h
+++ b/src/Networking/CANUtils.h
@@ -8,7 +8,7 @@ extern "C"
 }
 
 void InitializeCANSocket();
-void SendTestCANPacket();
+void SendCANPacket(const CANPacket &packet);
 CANPacket recvCANPacket();
 
 #endif

--- a/src/Networking/FakeBaseStation.cpp
+++ b/src/Networking/FakeBaseStation.cpp
@@ -1,0 +1,53 @@
+#include "NetworkConstants.h"
+
+int main()
+{
+	int listenfd, connfd;
+	char buffer[MAXLINE];
+	pid_t childpid;
+	ssize_t n;
+	socklen_t len;
+	const int on = 1;
+	struct sockaddr_in cliaddr, servaddr;
+	void sig_chld(int);
+
+	/* create listening TCP socket */
+	listenfd = socket(AF_INET, SOCK_STREAM, 0);
+	bzero(&servaddr, sizeof(servaddr));
+	servaddr.sin_family = AF_INET;
+	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+	servaddr.sin_port = htons(PORT);
+
+	// binding server addr structure to listenfd
+	bind(listenfd, (struct sockaddr*)&servaddr, sizeof(servaddr));
+	listen(listenfd, 10);
+
+  std::cout << "Waiting for rover....\n";
+	while (1) {
+    len = sizeof(cliaddr);
+    connfd = accept(listenfd, (struct sockaddr*)&cliaddr, &len);
+    if ((childpid = fork()) == 0) {
+      std::cout << "Connected to rover.\n";
+      close(listenfd);
+
+      std::string str;
+      while (1) {
+        std::cout << "Enter message in JSON format (no newlines): ";
+        std::getline(std::cin, str);
+        write(connfd, str.c_str(), str.length());
+
+        bzero(buffer, sizeof(buffer));
+        n = read(connfd, buffer, sizeof(buffer));
+        if (n <= 0 || strcmp(buffer, CLOSE_TCP) == 0) {
+          std::cout << "Disconnected from rover.\n";
+          break;
+        }
+        std::cout << "Message from rover: " << buffer << std::endl;
+      }
+
+      close(connfd);
+      exit(0);
+    }
+    close(connfd);
+	}
+}

--- a/src/Networking/FakeBaseStation.cpp
+++ b/src/Networking/FakeBaseStation.cpp
@@ -2,43 +2,47 @@
 
 int main()
 {
-	int listenfd, connfd;
-	char buffer[MAXLINE];
-	pid_t childpid;
-	ssize_t n;
-	socklen_t len;
-	const int on = 1;
-	struct sockaddr_in cliaddr, servaddr;
-	void sig_chld(int);
+  int listenfd, connfd;
+  char buffer[MAXLINE];
+  pid_t childpid;
+  ssize_t n;
+  socklen_t len;
+  const int on = 1;
+  struct sockaddr_in cliaddr, servaddr;
+  void sig_chld(int);
 
-	/* create listening TCP socket */
-	listenfd = socket(AF_INET, SOCK_STREAM, 0);
-	bzero(&servaddr, sizeof(servaddr));
-	servaddr.sin_family = AF_INET;
-	servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
-	servaddr.sin_port = htons(PORT);
+  /* create listening TCP socket */
+  listenfd = socket(AF_INET, SOCK_STREAM, 0);
+  bzero(&servaddr, sizeof(servaddr));
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+  servaddr.sin_port = htons(PORT);
 
-	// binding server addr structure to listenfd
-	bind(listenfd, (struct sockaddr*)&servaddr, sizeof(servaddr));
-	listen(listenfd, 10);
+  // binding server addr structure to listenfd
+  bind(listenfd, (struct sockaddr*)&servaddr, sizeof(servaddr));
+  listen(listenfd, 10);
 
   std::cout << "Waiting for rover....\n";
-	while (1) {
+  while (1)
+  {
     len = sizeof(cliaddr);
     connfd = accept(listenfd, (struct sockaddr*)&cliaddr, &len);
-    if ((childpid = fork()) == 0) {
+    if ((childpid = fork()) == 0)
+    {
       std::cout << "Connected to rover.\n";
       close(listenfd);
 
       std::string str;
-      while (1) {
+      while (1)
+      {
         std::cout << "Enter message in JSON format (no newlines): ";
         std::getline(std::cin, str);
         write(connfd, str.c_str(), str.length());
 
         bzero(buffer, sizeof(buffer));
         n = read(connfd, buffer, sizeof(buffer));
-        if (n <= 0 || strcmp(buffer, CLOSE_TCP) == 0) {
+        if (n <= 0 || strcmp(buffer, CLOSE_TCP) == 0)
+        {
           std::cout << "Disconnected from rover.\n";
           break;
         }
@@ -49,5 +53,5 @@ int main()
       exit(0);
     }
     close(connfd);
-	}
+  }
 }

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -1,0 +1,86 @@
+#include "NetworkConstants.h"
+extern "C"
+{
+    #include "../HindsightCAN/CANPacket.h"
+}
+
+#include <net/if.h>
+#include <cstring>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <aio.h>
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <aio.h>
+
+struct sockaddr_can can_addr;
+struct can_frame can_frame_;
+struct ifreq can_ifr;
+
+#include<iostream>
+
+int can_fd;
+
+void error(const char *msg) {
+  std::cout << msg << std::endl;
+  exit(1);
+}
+
+void InitializeCANSocket()
+{
+  if((can_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+    error("Failed to initialize CAN bus!");
+  }
+
+  strcpy(can_ifr.ifr_name, "can0");
+  ioctl(can_fd, SIOCGIFINDEX, &can_ifr);
+
+  can_addr.can_family = AF_CAN;
+  can_addr.can_ifindex = can_ifr.ifr_ifindex;
+
+  bind(can_fd, (struct sockaddr *)&can_addr, sizeof(can_addr));
+}
+
+void SendCANPacket()
+{
+  can_frame_.can_id = ConstructCANID(PACKET_PRIORITY_NORMAL, DEVICE_GROUP_JETSON, DEVICE_SERIAL_JETSON);
+  can_frame_.can_dlc = 7;
+  WriteSenderSerialAndPacketID(can_frame_.data, 0x36); // 0x36 is telemetry report
+  can_frame_.data[2] = 0x01; // current
+  for(int i = 3; i < 8; i++){
+      can_frame_.data[i] = 0;
+  }
+  can_frame_.data[5] = 0x01; // 256 milliamps
+
+  sendto(can_fd, &can_frame_, sizeof(struct can_frame),
+      0, (struct sockaddr*)&can_addr, sizeof(can_addr));
+}
+
+void recvCANPacket()
+{
+  socklen_t len = sizeof(can_addr);
+
+  std::cout << "Watiing for CAN packet" << std::endl;
+  recvfrom(can_fd, &can_frame_, sizeof(struct can_frame),
+                0, (struct sockaddr*)&can_addr, &len);
+
+  CANPacket packet;
+  packet.id = can_frame_.can_id;
+
+  for(int i = 0; i < can_frame_.can_dlc; i++){
+      packet.data[i] = can_frame_.data[i];
+  }
+}
+
+int main() {
+  InitializeCANSocket();
+  std::string str;
+  std::cout << "Press enter to send a CAN packet > ";
+  while(1) {
+    std::getline(std::cin, str);
+    SendCANPacket();
+  }
+}

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -1,79 +1,6 @@
-#include "NetworkConstants.h"
-extern "C"
-{
-    #include "../HindsightCAN/CANPacket.h"
-}
 
-#include <net/if.h>
-#include <cstring>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#include <sys/ioctl.h>
-#include <aio.h>
-
-#include <linux/can.h>
-#include <linux/can/raw.h>
-#include <aio.h>
-
-struct sockaddr_can can_addr;
-struct can_frame can_frame_;
-struct ifreq can_ifr;
-
+#include "CANUtils.h"
 #include<iostream>
-
-int can_fd;
-
-void error(const char *msg) {
-  std::cout << msg << std::endl;
-  exit(1);
-}
-
-void InitializeCANSocket()
-{
-  if((can_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
-    error("Failed to initialize CAN bus!");
-  }
-
-  strcpy(can_ifr.ifr_name, "can0");
-  ioctl(can_fd, SIOCGIFINDEX, &can_ifr);
-
-  can_addr.can_family = AF_CAN;
-  can_addr.can_ifindex = can_ifr.ifr_ifindex;
-
-  bind(can_fd, (struct sockaddr *)&can_addr, sizeof(can_addr));
-}
-
-void SendCANPacket()
-{
-  can_frame_.can_id = ConstructCANID(PACKET_PRIORITY_NORMAL, DEVICE_GROUP_JETSON, DEVICE_SERIAL_JETSON);
-  can_frame_.can_dlc = 7;
-  WriteSenderSerialAndPacketID(can_frame_.data, 0x36); // 0x36 is telemetry report
-  can_frame_.data[2] = 0x01; // current
-  for(int i = 3; i < 8; i++){
-      can_frame_.data[i] = 0;
-  }
-  can_frame_.data[5] = 0x01; // 256 milliamps
-
-  sendto(can_fd, &can_frame_, sizeof(struct can_frame),
-      0, (struct sockaddr*)&can_addr, sizeof(can_addr));
-}
-
-void recvCANPacket()
-{
-  socklen_t len = sizeof(can_addr);
-
-  std::cout << "Watiing for CAN packet" << std::endl;
-  recvfrom(can_fd, &can_frame_, sizeof(struct can_frame),
-                0, (struct sockaddr*)&can_addr, &len);
-
-  CANPacket packet;
-  packet.id = can_frame_.can_id;
-
-  for(int i = 0; i < can_frame_.can_dlc; i++){
-      packet.data[i] = can_frame_.data[i];
-  }
-}
 
 int main() {
   InitializeCANSocket();
@@ -81,6 +8,6 @@ int main() {
   std::cout << "Press enter to send a CAN packet > ";
   while(1) {
     std::getline(std::cin, str);
-    SendCANPacket();
+    SendTestCANPacket();
   }
 }

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -1,13 +1,15 @@
 
 #include "CANUtils.h"
-#include<iostream>
+#include "TestPackets.h"
+#include <iostream>
 
 int main() {
   InitializeCANSocket();
+
   std::string str;
   std::cout << "Press enter to send a CAN packet > ";
   while(1) {
     std::getline(std::cin, str);
-    SendTestCANPacket();
+    SendCANPacket(motorTelemetry());
   }
 }

--- a/src/Networking/Network.cpp
+++ b/src/Networking/Network.cpp
@@ -19,7 +19,8 @@ int base_station_fd;
 
 void InitializeBaseStationSocket()
 {
-  if ((base_station_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+  if ((base_station_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+  {
     perror("Base station socket creation failed");
     exit(1);
   }
@@ -31,7 +32,8 @@ void InitializeBaseStationSocket()
   servaddr.sin_port = htons(PORT);
   servaddr.sin_addr.s_addr = inet_addr(SERVER_IP);
 
-  if (connect(base_station_fd, (struct sockaddr*)&servaddr, sizeof(servaddr)) < 0) {
+  if (connect(base_station_fd, (struct sockaddr*)&servaddr, sizeof(servaddr)) < 0)
+  {
     perror("Base station connect failed");
     exit(1);
   }
@@ -42,11 +44,20 @@ void recvBaseStationPacket()
   char buffer[MAXLINE];
   bzero(buffer, sizeof(buffer));
   std::cout << "Waiting for base station packet" << std::endl;
-  read(base_station_fd, buffer, sizeof(buffer));
-  std::cout << "Message from base station: " << buffer << std::endl;
-  nlohmann::json parsed_message = nlohmann::json::parse(buffer);
-  // TODO proper input validation. Here we assume we got a dict with key "speed"
-  std::cout << parsed_message["speed"] << std::endl;
+  if (read(base_station_fd, buffer, sizeof(buffer)) < 0)
+  {
+    perror("Failed to read from base station");
+  }
+  else
+  {
+    std::cout << "Message from base station: " << buffer << std::endl;
+    nlohmann::json parsed_message = nlohmann::json::parse(buffer);
+    // TODO proper input validation. Here we assume we got a dict with key "speed"
+    std::cout << parsed_message["speed"] << std::endl;
+  }
   std::string serialized_status = Globals::status_data.dump();
-  write(base_station_fd, serialized_status.c_str(), serialized_status.length());
+  if (write(base_station_fd, serialized_status.c_str(), serialized_status.length()) < 0)
+  {
+    perror("Failed to send to base station");
+  }
 }

--- a/src/Networking/Network.cpp
+++ b/src/Networking/Network.cpp
@@ -74,7 +74,12 @@ void recvBaseStationPacket()
   char buffer[MAXLINE];
   bzero(buffer, sizeof(buffer));
   read(base_station_fd, buffer, sizeof(buffer));
-  std::cout << buffer << std::endl;
+  std::cout << "Message from base station: " << buffer << std::endl;
+  nlohmann::json parsed_message = nlohmann::json::parse(buffer);
+  // TODO proper input validation. Here we assume we got a dict with key "speed"
+  std::cout << parsed_message["speed"] << std::endl;
+  std::string serialized_status = Globals::status_data.dump();
+  write(base_station_fd, serialized_status.c_str(), serialized_status.length());
 }
 
 // TODO(sasha): We probably want all of this to use asynchronous IO

--- a/src/Networking/Network.cpp
+++ b/src/Networking/Network.cpp
@@ -13,92 +13,35 @@
 #include <sys/ioctl.h>
 #include <aio.h>
 
-#ifdef __linux__
-#include <linux/can.h>
-#include <linux/can/raw.h>
-#include <aio.h>
-
-struct sockaddr_can can_addr;
-struct can_frame can_frame_;
-struct ifreq can_ifr;
-#endif
-
 #include<iostream>
 
-int can_fd;
 int base_station_fd;
-
-void error(const char *msg) {
-  std::cout << msg << std::endl;
-  exit(1);
-}
-
-void InitializeCANSocket()
-{
-  #ifdef __linux__
-
-  if((can_fd = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
-    error("Failed to initialize CAN bus!");
-  }
-
-  strcpy(can_ifr.ifr_name, "can0");
-  ioctl(can_fd, SIOCGIFINDEX, &can_ifr);
-
-  can_addr.can_family = AF_CAN;
-  can_addr.can_ifindex = can_ifr.ifr_ifindex;
-
-  bind(can_fd, (struct sockaddr *)&can_addr, sizeof(can_addr));
-
-  #endif
-}
-
-// TODO(sasha): We probably want all of this to use asynchronous IO
-//              Check out POSIX aio.
-void recvCANPacket()
-{
-  #ifdef __linux__
-  socklen_t len = sizeof(can_addr);
-
-  // TODO: Probably should thread reading CAN
-  std::cout << "Watiing for CAN packet" << std::endl;
-  recvfrom(can_fd, &can_frame_, sizeof(struct can_frame),
-                0, (struct sockaddr*)&can_addr, &len);
-
-  CANPacket packet;
-  packet.id = can_frame_.can_id;
-
-  for(int i = 0; i < can_frame_.can_dlc; i++){
-      packet.data[i] = can_frame_.data[i];
-  }
-
-  ParseCANPacket(packet);
-
-  #endif
-}
 
 void InitializeBaseStationSocket()
 {
-	if ((base_station_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-    error("Base station socket creation failed");
-	}
+  if ((base_station_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    perror("Base station socket creation failed");
+    exit(1);
+  }
 
-	struct sockaddr_in servaddr;
-	bzero(&servaddr, sizeof(servaddr));
+  struct sockaddr_in servaddr;
+  bzero(&servaddr, sizeof(servaddr));
 
-	servaddr.sin_family = AF_INET;
-	servaddr.sin_port = htons(PORT);
-	servaddr.sin_addr.s_addr = inet_addr(SERVER_IP);
+  servaddr.sin_family = AF_INET;
+  servaddr.sin_port = htons(PORT);
+  servaddr.sin_addr.s_addr = inet_addr(SERVER_IP);
 
-	if (connect(base_station_fd, (struct sockaddr*)&servaddr, sizeof(servaddr)) < 0) {
-		error("Base station connect failed");
-	}
+  if (connect(base_station_fd, (struct sockaddr*)&servaddr, sizeof(servaddr)) < 0) {
+    perror("Base station connect failed");
+    exit(1);
+  }
 }
 
 void recvBaseStationPacket()
 {
   char buffer[MAXLINE];
   bzero(buffer, sizeof(buffer));
-  std::cout << "Watiing for base station packet" << std::endl;
+  std::cout << "Waiting for base station packet" << std::endl;
   read(base_station_fd, buffer, sizeof(buffer));
   std::cout << "Message from base station: " << buffer << std::endl;
   nlohmann::json parsed_message = nlohmann::json::parse(buffer);
@@ -106,67 +49,4 @@ void recvBaseStationPacket()
   std::cout << parsed_message["speed"] << std::endl;
   std::string serialized_status = Globals::status_data.dump();
   write(base_station_fd, serialized_status.c_str(), serialized_status.length());
-}
-
-void SendOutgoingNetworkPackets()
-{
-    for(const Packet &p : Globals::outgoing_packets)
-    {
-        if(p.kind == PacketKind::CAN){
-            #ifdef __linux__
-
-            can_frame_.can_id = p.address & 0x1FF;
-            can_frame_.can_dlc = 8;
-            for(int i = 0; i < 8; i++){
-                can_frame_.data[i] = p.payload[i];
-            }
-
-            sendto(can_fd, &can_frame_, sizeof(struct can_frame),
-                0, (struct sockaddr*)&can_addr, sizeof(can_addr));
-
-            #endif
-            //TODO Maybe?: Use aio
-            //aio_write(can_fd, p);
-        }
-        else if(p.kind == PacketKind::Network)
-            ;
-            //aio_write(net_fd, p);
-    }
-}
-
-// For testing uses
-// Used to manually send can bytes one at a time
-// Data is placed in outgoing packets list and will be processed in
-// SendOutgoingNetworkPackets() function 
-void TestCANPackets()
-{
-    Packet packet;
-    packet.kind = PacketKind::CAN;
-    std::cout << "Enter in Can ID" << std::endl;
-    int id;
-    std::cin >> id;
-    packet.address = id;
-
-    uint8_t data[Constants::PACKET_PAYLOAD_SIZE] = {0};
-    data[1] = 1;
-    data[2] = 2;
-    for(int i = 0; i < 8; i++){
-        packet.payload[i] = data[i];
-    }
-
-
-    Globals::outgoing_packets.push_back(packet);
-    std::cout << "Input Cycle Complete" << std::endl;
-
-}
-
-// Send JSON data to Mission Control
-void SendMissionControlStatus()
-{
-    // We're going to construct our json data here. We're going to use camel
-    // case for the json data fields to conform to Mission Control style guide
-    //nlohmann::json j;
-    //j["timestamp"] = p.timestamp;
-    //j["backLeftMotorCurrent"] = p.back_left_motor_current;
-    // TODO: Finish constructing JSON here
 }

--- a/src/Networking/Network.cpp
+++ b/src/Networking/Network.cpp
@@ -1,7 +1,7 @@
-#include "Globals.h"
+#include "../Globals.h"
 #include "Network.h"
-#include "Networking/ParseCAN.h"
-#include "Networking/NetworkConstants.h"
+#include "ParseCAN.h"
+#include "NetworkConstants.h"
 
 #include <cassert>
 

--- a/src/Networking/Network.h
+++ b/src/Networking/Network.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../Globals.h"
 #include "../Constants.h"
 #include "json.hpp"
 
@@ -26,4 +25,5 @@ struct Packet
 };
 
 void InitializeBaseStationSocket();
-void recvBaseStationPacket();
+int recvBaseStationPacket(char *buffer);
+void sendBaseStationPacket(const std::string &packet);

--- a/src/Networking/Network.h
+++ b/src/Networking/Network.h
@@ -25,7 +25,5 @@ struct Packet
     uint8_t payload[Constants::PACKET_PAYLOAD_SIZE];
 };
 
-void InitializeCANSocket();
 void InitializeBaseStationSocket();
-void recvCANPacket();
 void recvBaseStationPacket();

--- a/src/Networking/Network.h
+++ b/src/Networking/Network.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Globals.h"
-#include "Constants.h"
-#include "Networking/json.hpp"
+#include "../Globals.h"
+#include "../Constants.h"
+#include "json.hpp"
 
 extern "C"
 {
-    #include "HindsightCAN/CANPacket.h"
-    #include "HindsightCAN/CANCommon.h"
+    #include "../HindsightCAN/CANPacket.h"
+    #include "../HindsightCAN/CANCommon.h"
 }
 
 #include <cstdint>

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -1,0 +1,14 @@
+
+#include "Network.h"
+#include "../Globals.h"
+#include "json.hpp"
+#include <iostream>
+
+void ParseBaseStationPacket(char* buffer)
+{
+  std::cout << "Message from base station: " << buffer << std::endl;
+  nlohmann::json parsed_message = nlohmann::json::parse(buffer);
+  // TODO proper input validation. Here we assume we got a dict with key "speed"
+  std::cout << parsed_message["speed"] << std::endl;
+  sendBaseStationPacket(Globals::status_data.dump());
+}

--- a/src/Networking/ParseBaseStation.h
+++ b/src/Networking/ParseBaseStation.h
@@ -1,0 +1,7 @@
+
+#ifndef __PARSE_BASE_STATION_H__
+#define __PARSE_BASE_STATION_H__
+
+void ParseBaseStationPacket(char* buffer);
+
+#endif

--- a/src/Networking/ParseCAN.cpp
+++ b/src/Networking/ParseCAN.cpp
@@ -1,5 +1,4 @@
 #include "../Globals.h"
-#include "../Network.h"
 #include "json.hpp"
 
 // Expected JSON format of Globals::status_data: each key is a string from one of the group lists below

--- a/src/Networking/TestPackets.cpp
+++ b/src/Networking/TestPackets.cpp
@@ -1,0 +1,19 @@
+
+extern "C"
+{
+    #include "../HindsightCAN/Port.h"
+}
+
+CANPacket motorTelemetry()
+{
+  uint16_t CAN_ID = ConstructCANID(PACKET_PRIORITY_NORMAL, DEVICE_GROUP_JETSON, DEVICE_SERIAL_JETSON);
+  uint8_t testDataPacket[7];
+  WriteSenderSerialAndPacketID(testDataPacket, 0x36); // 0x36 is telemetry report
+  testDataPacket[2] = 0x01; // current
+  testDataPacket[3] = 0x00;
+  testDataPacket[4] = 0x00;
+  testDataPacket[5] = 0x01; // 256 milliamps
+  testDataPacket[6] = 0x00;
+
+  return ConstructCANPacket(CAN_ID, 0x07, testDataPacket);
+}

--- a/src/Networking/TestPackets.h
+++ b/src/Networking/TestPackets.h
@@ -1,0 +1,7 @@
+
+extern "C"
+{
+    #include "../HindsightCAN/Port.h"
+}
+
+CANPacket motorTelemetry();

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -1,5 +1,6 @@
 #include "../Globals.h"
 #include "ParseCAN.h"
+#include "TestPackets.h"
 extern "C"
 {
     #include "../HindsightCAN/Port.h"
@@ -30,17 +31,7 @@ TEST_CASE("Basic packet creation", "[CAN]")
 
 TEST_CASE("ParseCAN can handle telemetry", "[CAN]")
 {
-    uint16_t CAN_ID = ConstructCANID(PACKET_PRIORITY_NORMAL, DEVICE_GROUP_JETSON, DEVICE_SERIAL_JETSON);
-    uint8_t testDataPacket[7];
-    WriteSenderSerialAndPacketID(testDataPacket, 0x36); // 0x36 is telemetry report
-    testDataPacket[2] = 0x01; // current
-    testDataPacket[3] = 0x00;
-    testDataPacket[4] = 0x00;
-    testDataPacket[5] = 0x01; // 256 milliamps
-    testDataPacket[6] = 0x00;
-    CANPacket packet = ConstructCANPacket(CAN_ID, 0x07, testDataPacket);
-
-    ParseCANPacket(packet);
+    ParseCANPacket(motorTelemetry());
     std::cout << Globals::status_data << std::endl;
     REQUIRE(Globals::status_data.dump() == "{\"front_right_motor\":{\"current\":256}}");
 }

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -1,5 +1,4 @@
 #include "../Globals.h"
-#include "../Network.h"
 #include "ParseCAN.h"
 extern "C"
 {

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -1,8 +1,10 @@
 #include "CommandLineOptions.h"
 #include "Globals.h"
+#include "Networking/NetworkConstants.h"
 #include "Networking/Network.h"
 #include "Networking/CANUtils.h"
 #include "Networking/ParseCAN.h"
+#include "Networking/ParseBaseStation.h"
 
 void InitializeRover()
 {
@@ -14,13 +16,17 @@ int main(int argc, char **argv)
 {
     Globals::opts = ParseCommandLineOptions(argc, argv);
     InitializeRover();
+    CANPacket packet;
+    char buffer[MAXLINE];
     for(;;)
     {
-        // These methods also send packets if necessary, depending
-        // on what they receive. (Not implemented yet.)
-        CANPacket packet = recvCANPacket();
-        ParseCANPacket(packet);
-        recvBaseStationPacket();
+        if (recvCANPacket(&packet) != 0) {
+            ParseCANPacket(packet);
+        }
+        bzero(buffer, sizeof(buffer));
+        if (recvBaseStationPacket(buffer) != 0) {
+            ParseBaseStationPacket(buffer);
+        }
     }
     return 0;
 }

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -1,6 +1,7 @@
 #include "CommandLineOptions.h"
 #include "Globals.h"
 #include "Networking/Network.h"
+#include "Networking/CANUtils.h"
 
 void InitializeRover()
 {

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -4,7 +4,7 @@
 
 void InitializeRover()
 {
-    //InitializeCANSocket();
+    InitializeCANSocket();
     InitializeBaseStationSocket();
 }
 
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
     {
         // These methods also send packets if necessary, depending
         // on what they receive. (Not implemented yet.)
-        //recvCANPacket();
+        recvCANPacket();
         recvBaseStationPacket();
     }
     return 0;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -4,7 +4,8 @@
 
 void InitializeRover()
 {
-    // TODO(sasha): Call individual initialization functions
+    //InitializeCANSocket();
+    InitializeBaseStationSocket();
 }
 
 int main(int argc, char **argv)
@@ -13,13 +14,10 @@ int main(int argc, char **argv)
     InitializeRover();
     for(;;)
     {
-        //ParseIncomingNetworkPackets(); // NOTE(sasha): Since we're probably going to be using SocketCAN,
-                                       //              this includes both CAN and Network packets (maybe)
-
-	    //UpdateRoverState();
-        SendOutgoingNetworkPackets();
-        TestCANPackets();
-
+        // These methods also send packets if necessary, depending
+        // on what they receive. (Not implemented yet.)
+        //recvCANPacket();
+        recvBaseStationPacket();
     }
     return 0;
 }

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -2,6 +2,7 @@
 #include "Globals.h"
 #include "Networking/Network.h"
 #include "Networking/CANUtils.h"
+#include "Networking/ParseCAN.h"
 
 void InitializeRover()
 {
@@ -17,7 +18,8 @@ int main(int argc, char **argv)
     {
         // These methods also send packets if necessary, depending
         // on what they receive. (Not implemented yet.)
-        recvCANPacket();
+        CANPacket packet = recvCANPacket();
+        ParseCANPacket(packet);
         recvBaseStationPacket();
     }
     return 0;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -1,6 +1,6 @@
 #include "CommandLineOptions.h"
 #include "Globals.h"
-#include "Network.h"
+#include "Networking/Network.h"
 
 void InitializeRover()
 {


### PR DESCRIPTION
This is a fairly big PR that moves around a lot of files. The main changes:

(1) Create FakeBaseStation and FakeCANBoard executables. Run these and Rover in three separate processes and watch the Rover handle requests from both directions! (You'll need to set up a virtural can network using the shell commands shown in CANUtils.cpp.)

(2) Improves error handling for network calls

(3) Pulls out CAN I/O, test CAN packet construction, and Base Station message handling into separate files.