### PR TITLE
Update README.md to correct OpenCV installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ and as such is needed to compile the project.
 The setup process takes some time and will use a lot of CPU, but it's fairly
 straightforward and should only need to be done once.
 
+We need an extra module (ARUco) for OpenCV for the AR tag detection code which
+is not bundled with OpenCV, so you will have to install that module before
+building OpenCV. The below instructions will cover this.
+
 ### On Windows (with Windows Subsystem for Linux)
 Open the WSL terminal and run the following commands (you can paste with right
 click):
@@ -20,20 +24,36 @@ click):
 2. `sudo apt install unzip git cmake g++ libgtk2.0-dev pkg-config libavcodec-dev
    libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev
    libtiff-dev libdc1394-22-dev`
-3. `wget https://github.com/opencv/opencv/archive/3.4.7.zip`
-4. `unzip 3.4.7.zip`
-5. `cd opencv-3.4.7`
-6. `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -Bbuild
-   .`
-7. `sudo cmake --build build --target install -- -j8` (**Replace the number 8 here
-   with the number of CPU cores on your computer.**)
+   
+Now, to install the extra modules:
+3. `git clone https://github.com/opencv/opencv_contrib`
+4. `cd opencv_contrib`
+5. `git checkout 3.4.7`
+6. `mkdir selected_modules`
+7. `cp -r modules/aruco selected_modules/`
+8. `cd`
+
+Now, to install and build OpenCV, with the extra modules:
+9. `wget https://github.com/opencv/opencv/archive/3.4.7.zip`
+10. `unzip 3.4.7.zip`
+11. `cd opencv-3.4.7`
+12. `mkdir build`
+13. `cd build`
+14. `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local
+    -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/selected_modules ..` 
+15. `make -j$(nproc)` (The command `nproc` here will return the number of CPU
+   cores on your computer, and will enable `make` to build in parallel, which
+   will make the build process go faster.) This step will take a long
+   time and use nearly 100% CPU for that entire time, so be warned.
+16. `sudo make install`
    
 ### On GNU/Linux
 If you are using a GNU/Linux distribution that supports APT, the instructions
 should be the same as for Windows above. If you are using a different
 distribution, the only steps that should be different are the first two, which
-are installing libraries OpenCV depends on. In this case you should install
-those libraries with your distribution's package manager.
+are installing libraries and utilities OpenCV depends on. In this case you
+should install those libraries and utilities with your distribution's package
+manager.
 
 ### On Mac
 There is a Homebrew package available for OpenCV on Mac OS. Open the Terminal
@@ -63,20 +83,20 @@ There is a Homebrew package for Catch2 as well. Open the Terminal and run this
 command:
 `brew install catch2`
 
-## Setup CMake
-CMake is a tool we use that helps us compile our project with the libraries we
-use. This assumes that you have Ubuntu installed and configured.
+## Setup Project Repository
+This step will require you to have CMake and Git. If you've followed the above
+OpenCV setup instructions, you should have these installed already. The
+following instructions will assume you have them installed.
 
-If you are using Windows, type this into your Ubuntu terminal and hit "return"
-to install the necessary files:
-`sudo apt install cmake g++ git`
+These instructions will also assume you are using a Unix-like environment;
+GNU/Linux and Mac users should be fine here, Windows users should run these
+commands in their WSL terminal.
 
-If you are using MacOS, type this instead.
-`brew install cmake git`
+Enter the home directory (or wherever you would like to put the project files).
+`cd ~` (If you would like to put the project somewhere else, replace `~` with
+the folder path.)
 
-The terminal will prompt you for a password and confirmation; proceed.
-
-When done, clone the repository.
+Clone the repository.
 `git clone https://github.com/huskyroboticsteam/PY2020/`
 
 Navigate into the repository.
@@ -89,6 +109,8 @@ Ensure you have CMake installed.
 Run
 
 ```
-cmake -Bbuild ./src
-cmake --build build
+mkdir -p build
+cd build
+cmake ../src
+make -j$(nproc)
 ```


### PR DESCRIPTION
The install instructions were incorrect and used a flag that only exists in newer versions of CMake, that (strangely) older versions just silently ignore. I changed this to just use the "old" way of creating and using a CMake build directory.

Additionally, the new AR detection code that is being worked on will require use of the ARUco module for OpenCV; this module isn't built in unfortunately so it needs to be downloaded and installed before OpenCV is built. I've updated the instructions to show how to do this.