### PR TITLE
Fix number formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ click):
    libtiff-dev libdc1394-22-dev`
    
 Now, to install the extra modules:
+
 3. `git clone https://github.com/opencv/opencv_contrib`
 4. `cd opencv_contrib`
 5. `git checkout 3.4.7`
@@ -34,6 +35,7 @@ Now, to install the extra modules:
 8. `cd`
 
 Now, to install and build OpenCV, with the extra modules:
+
 9. `wget https://github.com/opencv/opencv/archive/3.4.7.zip`
 10. `unzip 3.4.7.zip`
 11. `cd opencv-3.4.7`


### PR DESCRIPTION
Bruh moment... Apparently if you don't have a line break before continuing the numbered list in Markdown, it just puts all the items in a paragraph instead of making a list. I fixed it now. :man_facepalming: 

Really not sure how I messed this one up folks :/