### PR TITLE
Update to new simulator master

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,7 +117,7 @@ add_executable(visualizer_test
   )
 
 list(APPEND simulator_libs
-  sfml-graphics sfml-window sfml-system X11 pthread)
+  sfml-graphics sfml-window sfml-system pthread)
 
 target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})


### PR DESCRIPTION
This new version of the simulator avoids the dependency on the `X11` library and does not try to launch windows from worker threads (which apparently is not allowed on OSX). However, I think it requires updating to SFML 2.5, which may require building from source.