### PR TITLE
Estop

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -1,4 +1,5 @@
 #include "Autonomous.h"
+#include "Globals.h"
 #include "simulator/world_interface.h"
 #include <cmath>
 
@@ -40,8 +41,9 @@ double Autonomous::angleToTarget(pose_t gpsPose) {
     return theta - gpsPose(2);
 }
 
-void Autonomous::autonomyIter() 
+void Autonomous::autonomyIter()
 {
+  if (!Globals::AUTONOMOUS) return;
   transform_t gps = readGPS(); // <--- has some heading information
   transform_t odom = readOdom();
   points_t lidar = readLidarScan();
@@ -102,7 +104,7 @@ void Autonomous::autonomyIter()
     if(!lidar.empty()) {
         speed = 5.0;
     }
-    setCmdVel(dtheta, speed);
+    if (!Globals::E_STOP) setCmdVel(dtheta, speed);
   }
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND RoverCommonTest
   Networking/IK.cpp
   Networking/ParseCAN.cpp
   Networking/log.cpp
+  Networking/motor_interface.cpp
   HindsightCAN/CANPacket.c
   HindsightCAN/CANCommon.c
   HindsightCAN/PortTemplate.c
@@ -64,7 +65,6 @@ add_executable(RoverSim
 add_executable(tests
   ${RoverCommonTest}
   Tests.cpp
-  simulator/noop_world.cpp
   # AR Detection tests
   ar/TagUnitTests.cpp
   ar/Tag.cpp
@@ -72,6 +72,7 @@ add_executable(tests
   Networking/tests.cpp
   Networking/TestPackets.cpp
   Networking/NetworkingStubs.cpp
+  Networking/real_world_interface.cpp
   # Autonomy tests
   SimpleAutonomousTester.cpp
   FakeMap.cpp

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -4,7 +4,11 @@
 
 #include <vector>
 
-CommandLineOptions Globals::opts;
-RoverState Globals::curr_state;
-nlohmann::json Globals::status_data;
-nlohmann::json Globals::motor_status;
+namespace Globals {
+  CommandLineOptions opts;
+  RoverState curr_state;
+  nlohmann::json status_data;
+  nlohmann::json motor_status;
+  bool E_STOP = false;
+  bool AUTONOMOUS = true;
+}

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -21,4 +21,6 @@ namespace Globals
     extern RoverState curr_state;
     extern nlohmann::json status_data;
     extern nlohmann::json motor_status;
+    extern bool E_STOP;
+    extern bool AUTONOMOUS;
 }

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -1,5 +1,6 @@
 
 #include "ParseBaseStation.h"
+#include "motor_interface.h"
 #include "../Constants.h"
 #include <iostream>
 

--- a/src/Networking/NetworkConstants.h
+++ b/src/Networking/NetworkConstants.h
@@ -11,7 +11,7 @@
 #include <cstring>
 #include <cstdlib>
 
-#define PORT 5000 
+#define PORT 3001
 #define MAXLINE 1024
 #define CLOSE_TCP "~~closetcp~~"
 #define SERVER_IP "127.0.0.1"

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -75,9 +75,7 @@ bool ParseBaseStationPacket(char const* buffer)
 }
 
 bool ParseEmergencyStop(json &message) {
-  // TODO shouldn't there be some more guaranteed way to do this, e.g. by
-  // cutting the power to the motors?
-  // TODO this should also stop the arm motors
+  // TODO actually send e-stop packet (packet id 0x30 broadcast)
   bool success = setCmdVel(0,0);
   Globals::E_STOP = true;
   bool release;

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -1,51 +1,20 @@
 
 #include "Network.h"
-#include "../Globals.h"
-#include "CANUtils.h"
-#include "ParseCAN.h"
 #include "log.h"
 #include "IK.h"
+#include "motor_interface.h"
 #include "ParseBaseStation.h"
 #include <cmath>
 #include <tgmath.h>
-
-extern "C"
-{
-    #include "../HindsightCAN/CANMotorUnit.h"
-}
+#include "../simulator/world_interface.h"
+#include "../Globals.h"
 
 #include <iostream>
 
 using nlohmann::json;
 
-// It's important that all of these vectors are sorted in the same order (the indices correspond)
-std::map<std::string, std::vector<std::string>> possible_keys = {
-	{"motor", {"mode", "P", "I", "D", "PID target", "PWM target"}},
-};
-std::vector<int> motor_packet_ids = {
-  ID_MOTOR_UNIT_MODE_SEL,
-  ID_MOTOR_UNIT_PID_P_SET,
-  ID_MOTOR_UNIT_PID_I_SET,
-  ID_MOTOR_UNIT_PID_D_SET,
-  ID_MOTOR_UNIT_PID_POS_TGT_SET,
-  ID_MOTOR_UNIT_PWM_DIR_SET
-};
-std::vector<int> motor_packet_lengths = {
-  2, 5, 5, 5, 5, 5
-};
-
-bool SendCANPacketToMotor(json &message, int key_idx, uint16_t CAN_ID);
 bool ParseDrivePacket(json &message);
-
-int getIndex(const std::vector<std::string> &arr, std::string &value)
-{
-  for (int i = 0; i < arr.size(); i++) {
-    if (arr[i] == value) {
-      return i;
-    }
-  }
-  return -1;
-}
+bool ParseEmergencyStop(json &message);
 
 bool sendError(std::string const &msg)
 {
@@ -79,7 +48,14 @@ bool ParseBaseStationPacket(char const* buffer)
     return sendError("Could not find message type");
   }
   log(LOG_DEBUG, "Message type: " + type);
-  bool success;
+
+  bool success = false;
+  if (type == "estop") {
+    success = ParseEmergencyStop(parsed_message);
+  } else if (Globals::E_STOP) {
+    return sendError("Emergency stop is activated");
+  }
+
   if (type == "ik") {
     success = ParseIKPacket(parsed_message);
   }
@@ -89,6 +65,7 @@ bool ParseBaseStationPacket(char const* buffer)
   else if (type == "motor") {
     success = ParseMotorPacket(parsed_message);
   }
+
   if (success)
   {
     json response = {{"status", "ok"}};
@@ -97,47 +74,31 @@ bool ParseBaseStationPacket(char const* buffer)
   return success;
 }
 
-bool ParseMotorPacket(json &message)
-{
-  std::string motor;
+bool ParseEmergencyStop(json &message) {
+  // TODO shouldn't there be some more guaranteed way to do this, e.g. by
+  // cutting the power to the motors?
+  // TODO this should also stop the arm motors
+  bool success = setCmdVel(0,0);
+  Globals::E_STOP = true;
+  bool release;
   try
   {
-    motor = message["motor"];
+    release = message["release"];
   }
   catch (json::type_error)
   {
-    return sendError("No motor specified");
-  }
-  int motor_serial = getIndex(motor_group, motor);
-  if (motor_serial < 0)
-  {
-    return sendError("Unrecognized motor " + motor);
-  }
-  log(LOG_DEBUG, "Parsing motor packet for motor " + motor);
-  Globals::motor_status[motor]["motor"] = motor;
-  log(LOG_DEBUG, "Original status: " + Globals::motor_status[motor].dump());
-
-
-  for (int key_idx = 0; key_idx < possible_keys["motor"].size(); key_idx++) {
-    std::string key = possible_keys["motor"][key_idx];
-    if (message[key] != nullptr && message[key] != Globals::motor_status[motor][key]) {
-      log(LOG_DEBUG, "Updating " + key);
-      uint16_t CAN_ID = ConstructCANID(PACKET_PRIORITY_NORMAL,
-                                       DEVICE_GROUP_MOTOR_CONTROL,
-                                       motor_serial);
-      if (SendCANPacketToMotor(message, key_idx, CAN_ID)) {
-        Globals::motor_status[motor][key] = message[key];
-      } else {
-        return sendError("Failed to send CAN packet to motor " + motor);
-      }
-    }
+    return sendError("Malformatted estop packet");
   }
 
-  return true;
+  if (release) {
+    Globals::E_STOP = false;
+    return success;
+  } else {
+    return success;
+  }
 }
 
-bool ParseDrivePacket(json &message)
-{
+bool ParseDrivePacket(json &message) {
   double fb, lr;
   try
   {
@@ -152,56 +113,6 @@ bool ParseDrivePacket(json &message)
   {
     return sendError("Drive targets not within bounds +/- 1.0");
   }
-  // TODO I'm curious how intuitive it would be to use remote control with wheel velocities rather
-  // than kinematic velocities. That would actually allow the rover to go faster, I think.
-  // Another alternative: add a boolean "wheel_velocities" indicating which mode to use
-  // (if true, the other keys should just be "right" and "left").
-  double right = (fb + lr)/2;
-  double left =  (fb - lr)/2;
-  int max_pwm = 1000; // TODO figure out what is the maximum value the hardware supports
-  int right_pwm = (int) max_pwm * right;
-  int left_pwm = (int) max_pwm * left;
-  json packet = {};
-  packet["type"] = "motor";
-  packet["mode"] = "PWM";
-  // TODO we may need to switch some of these signs
-  packet["PWM target"] = right_pwm;
-  packet["motor"] = "front_right_wheel";
-  ParseMotorPacket(packet);
-  packet["motor"] = "back_right_wheel";
-  ParseMotorPacket(packet);
-  packet["PWM target"] = left_pwm;
-  packet["motor"] = "front_left_wheel";
-  ParseMotorPacket(packet);
-  packet["motor"] = "back_left_wheel";
-  ParseMotorPacket(packet);
-  return true;
-}
-
-bool SendCANPacketToMotor(json &message, int key_idx, uint16_t CAN_ID) {
-  std::string key = possible_keys["motor"][key_idx];
-  int length = motor_packet_lengths[key_idx];
-  int packet_id = motor_packet_ids[key_idx];
-  uint8_t data[length];
-  WritePacketIDOnly(data, packet_id);
-
-  if (key == "mode") {
-    std::string mode = message[key];
-    if (mode == "PWM") {
-      data[1] = MOTOR_UNIT_MODE_PWM;
-    } else if (mode == "PID") {
-      data[1] = MOTOR_UNIT_MODE_PID;
-    } else {
-      return sendError("Unrecognized mode " + mode);
-    }
-  }
-  else // key is one of P, I, D, PID target, or PWM target
-  {
-    uint32_t val = message[key];
-    PackIntIntoDataMSBFirst(data, val, 1);
-  }
-
-  CANPacket p = ConstructCANPacket(CAN_ID, length, data);
-  sendCANPacket(p);
-  return true;
+  // TODO do we need to scale or invert these?
+  return setCmdVel(lr, fb);
 }

--- a/src/Networking/ParseBaseStation.h
+++ b/src/Networking/ParseBaseStation.h
@@ -5,7 +5,6 @@
 #include "json.hpp"
 using nlohmann::json;
 bool ParseBaseStationPacket(char const* buffer);
-bool ParseMotorPacket(json &message);
 bool sendError(std::string const &msg);
 
 #endif

--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -1,0 +1,113 @@
+
+#include <string>
+#include "log.h"
+#include "CANUtils.h"
+#include "ParseCAN.h"
+extern "C"
+{
+    #include "../HindsightCAN/CANMotorUnit.h"
+}
+#include "../Globals.h"
+
+#include "../simulator/world_interface.h"
+#include "../simulator/utils.h"
+#include "ParseBaseStation.h"
+#include "motor_interface.h"
+
+// It's important that all of these vectors are sorted in the same order (the indices correspond)
+std::map<std::string, std::vector<std::string>> possible_keys = {
+	{"motor", {"mode", "P", "I", "D", "PID target", "PWM target"}},
+};
+std::vector<int> motor_packet_ids = {
+  ID_MOTOR_UNIT_MODE_SEL,
+  ID_MOTOR_UNIT_PID_P_SET,
+  ID_MOTOR_UNIT_PID_I_SET,
+  ID_MOTOR_UNIT_PID_D_SET,
+  ID_MOTOR_UNIT_PID_POS_TGT_SET,
+  ID_MOTOR_UNIT_PWM_DIR_SET
+};
+std::vector<int> motor_packet_lengths = {
+  2, 5, 5, 5, 5, 5
+};
+
+bool SendCANPacketToMotor(json &message, int key_idx, uint16_t CAN_ID);
+
+int getIndex(const std::vector<std::string> &arr, std::string &value)
+{
+  for (int i = 0; i < arr.size(); i++) {
+    if (arr[i] == value) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+bool ParseMotorPacket(json &message)
+{
+  if (Globals::E_STOP) return sendError("Emergency stop is activated");
+
+  std::string motor;
+  try
+  {
+    motor = message["motor"];
+  }
+  catch (json::type_error)
+  {
+    return sendError("No motor specified");
+  }
+  int motor_serial = getIndex(motor_group, motor);
+  if (motor_serial < 0)
+  {
+    return sendError("Unrecognized motor " + motor);
+  }
+
+  log(LOG_DEBUG, "Parsing motor packet for motor " + motor);
+  Globals::motor_status[motor]["motor"] = motor;
+  log(LOG_DEBUG, "Original status: " + Globals::motor_status[motor].dump());
+
+
+  for (int key_idx = 0; key_idx < possible_keys["motor"].size(); key_idx++) {
+    std::string key = possible_keys["motor"][key_idx];
+    if (message[key] != nullptr && message[key] != Globals::motor_status[motor][key]) {
+      log(LOG_DEBUG, "Updating " + key);
+      uint16_t CAN_ID = ConstructCANID(PACKET_PRIORITY_NORMAL,
+                                       DEVICE_GROUP_MOTOR_CONTROL,
+                                       motor_serial);
+      if (SendCANPacketToMotor(message, key_idx, CAN_ID)) {
+        Globals::motor_status[motor][key] = message[key];
+      } else {
+        return sendError("Failed to send CAN packet to motor " + motor);
+      }
+    }
+  }
+
+  return true;
+}
+
+bool SendCANPacketToMotor(json &message, int key_idx, uint16_t CAN_ID) {
+  std::string key = possible_keys["motor"][key_idx];
+  int length = motor_packet_lengths[key_idx];
+  int packet_id = motor_packet_ids[key_idx];
+  uint8_t data[length];
+  WritePacketIDOnly(data, packet_id);
+
+  if (key == "mode") {
+    std::string mode = message[key];
+    if (mode == "PWM") {
+      data[1] = MOTOR_UNIT_MODE_PWM;
+    } else if (mode == "PID") {
+      data[1] = MOTOR_UNIT_MODE_PID;
+    } else {
+      return sendError("Unrecognized mode " + mode);
+    }
+  }
+  else // key is one of P, I, D, PID target, or PWM target
+  {
+    uint32_t val = message[key];
+    PackIntIntoDataMSBFirst(data, val, 1);
+  }
+
+  CANPacket p = ConstructCANPacket(CAN_ID, length, data);
+  sendCANPacket(p);
+  return true;
+}

--- a/src/Networking/motor_interface.h
+++ b/src/Networking/motor_interface.h
@@ -1,0 +1,7 @@
+
+#pragma once
+
+#include "json.hpp"
+using nlohmann::json;
+
+bool ParseMotorPacket(json &message);

--- a/src/Networking/real_world_interface.cpp
+++ b/src/Networking/real_world_interface.cpp
@@ -1,0 +1,62 @@
+#include "../simulator/world_interface.h"
+#include "../simulator/utils.h"
+#include "json.hpp"
+#include "motor_interface.h"
+using nlohmann::json;
+
+void world_interface_init() {
+  return;
+}
+
+bool setCmdVel(double dtheta, double dx)
+{
+  // TODO do we need to scale or invert these values?
+  double lr = dtheta;
+  double fb = dx;
+  // TODO I'm curious how intuitive it would be to use remote control with wheel velocities rather
+  // than kinematic velocities. That would actually allow the rover to go faster, I think.
+  // Another alternative: add a boolean "wheel_velocities" indicating which mode to use
+  // (if true, the other keys should just be "right" and "left").
+  double right = (fb + lr)/2;
+  double left =  (fb - lr)/2;
+  int max_pwm = 1000; // TODO figure out what is the maximum value the hardware supports
+  int right_pwm = (int) max_pwm * right;
+  int left_pwm = (int) max_pwm * left;
+  json packet = {};
+  packet["type"] = "motor";
+  packet["mode"] = "PWM";
+  // TODO we may need to switch some of these signs
+  packet["PWM target"] = right_pwm;
+  packet["motor"] = "front_right_wheel";
+  ParseMotorPacket(packet);
+  packet["motor"] = "back_right_wheel";
+  ParseMotorPacket(packet);
+  packet["PWM target"] = left_pwm;
+  packet["motor"] = "front_left_wheel";
+  ParseMotorPacket(packet);
+  packet["motor"] = "back_left_wheel";
+  ParseMotorPacket(packet);
+  return true;
+}
+
+// Everything below this line still needs to be implemented
+
+points_t readLidarScan() {
+  return {};
+}
+
+points_t readLandmarks() {
+  return {};
+}
+
+transform_t readGPS() {
+  return toTransform({0,0,0});
+}
+
+transform_t readOdom() {
+  return toTransform({0,0,0});
+}
+
+URCLeg getLeg(int index) {
+  return URCLeg { -1, -1, {0.,0.,0.}};
+}

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -188,3 +188,15 @@ TEST_CASE("Respects joint limits", "[BaseStation]")
     REQUIRE(m["msg"] == "IK solution outside joint limits for shoulder");
 }
 
+TEST_CASE("Does not activate motors if e-stopped", "[BaseStation]")
+{
+    clearPackets();
+    char const *msg = "{\"type\":\"estop\",\"release\":false}";
+    REQUIRE(ParseBaseStationPacket(msg) == true);
+    json m = json::parse(popBaseStationPacket());
+    REQUIRE(m["status"] == "ok");
+    char const *msg2 = "{\"type\":\"drive\",\"forward_backward\":0.3,\"left_right\":-0.4}";
+    REQUIRE(ParseBaseStationPacket(msg2) == false);
+    m = json::parse(popBaseStationPacket());
+    REQUIRE(m["msg"] == "Emergency stop is activated");
+}


### PR DESCRIPTION
This branch contains a lot of changes that together make it so that we can send e-stop commands from the Mission Control interface, and the robot in the simulator will stop moving! There's a corresponding branch in the Mission Control repo; I'll make a PR for that after this. Here's a video showing the e-stop button in action: https://huskyrobotics19-20.slack.com/files/USTU8J78C/F0199Q8EYUR/e-stop-rover.mp4

* Add some more global variables to track autonomous mode and whether the robot is e-stopped
* Add a new base station message type "estop" and corresponding `ParseEmergencyStop` method and test
* Pull out the motor packet handling from `ParseBaseStation.cpp` into a new file `motor_interface.cpp`
* Change handling of "drive" messages to use `setCmdVel` instead of directly sending CAN packets (so that they work with the simulator)
* Accordingly, pull the CAN-based handling of "drive" messages into a new file `real_world_interface.cpp`
* Change the base station port to the one used in the MissionControl repo