### PR TITLE
Use Compatible Catch2 Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ CMake, or Homebrew for Mac users.
 Open the WSL terminal and run the following commands:
 1. `git clone https://github.com/catchorg/Catch2.git`
 2. `cd Catch2`
-3. `cmake -Bbuild -H. -DBUILD_TESTING=OFF`
-4. `sudo cmake --build build/ --target install`
+3. `git checkout v2.13.2`
+4. `cmake -Bbuild -H. -DBUILD_TESTING=OFF`
+5. `sudo cmake --build build/ --target install`
 
 ### On GNU/Linux
 The instructions should be the same as for Windows above.

--- a/tests-docker-action/entrypoint.sh
+++ b/tests-docker-action/entrypoint.sh
@@ -11,6 +11,7 @@ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/include/eigen3
 git submodule update --init --recursive
 git clone https://github.com/catchorg/Catch2.git
 cd ./Catch2
+git checkout v2.13.2
 cmake -B./build -H. -DBUILD_TESTING=OFF
 cmake --build ./build/ --target install
 cd ..


### PR DESCRIPTION
The default branch of the Catch2 GitHub repository is now on a version 3 preview which has a different file organization and naming scheme that causes errors when trying to find catch2/catch.hpp when building this repository (on both local machines and the Docker CI). This pull request ensures that we are using a compatible version of catch2 that includes a catch.hpp file by checking out to the latest release on the v2.x branch of the Catch2 GitHub repository. The README and docker entrypoint have been updated to include this extra step.

This could be a temporary fix if we plan to move to v3 of Catch2, as that would require some more effort.