### PR TITLE
Improve rate limiting for Rover.cpp and simulator

### DIFF
--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -1,3 +1,7 @@
+#include <time.h>
+#include <sys/time.h>
+#include <ctime>
+
 #include "CommandLineOptions.h"
 #include "Globals.h"
 #include "Networking/NetworkConstants.h"
@@ -14,6 +18,8 @@ void InitializeRover()
     InitializeBaseStationSocket();
 }
 
+const double CONTROL_HZ = 10.0;
+
 int main(int argc, char **argv)
 {
     world_interface_init();
@@ -25,8 +31,10 @@ int main(int argc, char **argv)
     PointXY target { 3.14, 2.71 };
     Autonomous autonomous(target);
     char buffer[MAXLINE];
+    struct timeval tp0, tp_start;
     for(;;)
     {
+        gettimeofday(&tp_start, NULL);
         if (recvCANPacket(&packet) != 0) {
             ParseCANPacket(packet);
         }
@@ -35,6 +43,13 @@ int main(int argc, char **argv)
             ParseBaseStationPacket(buffer);
         }
         autonomous.autonomyIter();
+
+        gettimeofday(&tp0, NULL);
+        long elapsedUsecs = (tp0.tv_sec - tp_start.tv_sec) * 1000 * 1000 + (tp0.tv_usec - tp_start.tv_usec);
+        long desiredUsecs = 1000 * 1000 / CONTROL_HZ;
+        if (desiredUsecs - elapsedUsecs > 0) {
+            usleep(desiredUsecs - elapsedUsecs);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Rover.cpp was not rate-limited at all, and the simulator did rate-limiting only approximately (assuming the other code took no time to execute). This fixes both. (Since the simulator code is a submodule, this was updated upstream.)

Arguably, we should treat the simulator as a black box and handle its weird rate limiting with code on the rover, since executing things on the real robot are bound to have similar issues. Still, there's no real reason not to make this cleaner.