### PR TITLE
Fixed bug in KF math

### DIFF
--- a/src/filters/KalmanFilter.h
+++ b/src/filters/KalmanFilter.h
@@ -88,6 +88,8 @@ public:
 		matrix P = DARE(systemMat.transpose(), outputMat.transpose(), stateCovariance,
 						measurementCovariance);
 
+		// The following math is derived from the asymptotic form:
+		// https://en.wikipedia.org/wiki/Kalman_filter#Asymptotic_form
 		matrix S = outputMat * P * outputMat.transpose() + measurementCovariance;
 		// This is the Kalman gain matrix, used to weight the GPS data against the model data
 		matrix gainMatrix =

--- a/src/filters/KalmanFilter.h
+++ b/src/filters/KalmanFilter.h
@@ -91,7 +91,7 @@ public:
 		matrix S = outputMat * P * outputMat.transpose() + measurementCovariance;
 		// This is the Kalman gain matrix, used to weight the GPS data against the model data
 		matrix gainMatrix =
-			S.transpose().colPivHouseholderQr().solve((outputMat * P.transpose()).transpose());
+			S.transpose().colPivHouseholderQr().solve(outputMat * P.transpose()).transpose();
 
 		return KalmanFilter(systemMat, inputMat, outputMat, stateCovariance,
 							measurementCovariance, gainMatrix);


### PR DESCRIPTION
I was looking over my math and I realized I had an extra set of parenthesis that changed the meaning of the equation.

It should be solving the equation S^T * K^T = A * P^T for the matrix K, but it was instead solving S^T * K = (A * P^T)^T for K, which is incorrect.