### PR TITLE
Switch target from PointXY -> URCLeg

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -10,14 +10,14 @@ constexpr float PI = M_PI;
 constexpr double KP_ANGLE = 2;
 constexpr double DRIVE_SPEED = 8;
 
-Autonomous::Autonomous(PointXY _target, double controlHz)
+Autonomous::Autonomous(const URCLeg &_target, double controlHz)
 	: target(_target), poseEstimator({0.8, 0.8, 0.6}, {2, 2, PI / 24}, 1.0 / controlHz),
 	  state(0), targetHeading(-1), forwardCount(-1), rightTurn(false), calibrated(false),
 	  landmarkFilter()
 {
 }
 
-Autonomous::Autonomous(PointXY _target, double controlHz, const pose_t &startPose)
+Autonomous::Autonomous(const URCLeg &_target, double controlHz, const pose_t &startPose)
 	: Autonomous(_target, controlHz)
 {
 	poseEstimator.reset(startPose);
@@ -33,8 +33,8 @@ bool Autonomous::arrived(const pose_t &pose) const
 {
 	double currX = pose[0];
 	double currY = pose[1];
-	return util::almostEqual(currX, (double)target.x, 0.5) &&
-		   util::almostEqual(currY, (double)target.y, 0.5);
+	return util::almostEqual(currX, (double)target.approx_GPS(0), 0.5) &&
+		   util::almostEqual(currY, (double)target.approx_GPS(1), 0.5);
 }
 
 std::vector<PointXY> Autonomous::points_tToPointXYs(const points_t &pnts) const
@@ -49,8 +49,8 @@ std::vector<PointXY> Autonomous::points_tToPointXYs(const points_t &pnts) const
 
 double Autonomous::angleToTarget(const pose_t &gpsPose) const
 {
-	float dy = target.y - (float)gpsPose(1);
-	float dx = target.x - (float)gpsPose(0);
+	float dy = target.approx_GPS(1) - (float)gpsPose(1);
+	float dx = target.approx_GPS(0) - (float)gpsPose(0);
 	double theta = std::atan2(dy, dx);
 	return theta - gpsPose(2);
 }
@@ -132,7 +132,7 @@ void Autonomous::autonomyIter()
 
 	// get landmark data and filter out invalid data points
 	points_t landmarks = readLandmarks();
-	point_t firstLandmark = landmarks[0];
+	point_t leftPostLandmark = landmarks[target.left_post_id];
 
 	// get the latest pose estimation
 	poseEstimator.correct(gps);
@@ -148,12 +148,12 @@ void Autonomous::autonomyIter()
 	}
 	else
 	{
-		PointXY driveTarget = target;
-		if (dist(target, point_tToPointXY(pose)) < 25)
+		PointXY driveTarget = getTarget();
+		if (dist(driveTarget, point_tToPointXY(pose)) < 25)
 		{
 			// if we have some existing data or new data, set the target using the landmark
 			// data
-			bool landmarkVisible = firstLandmark[2] != 0;
+			bool landmarkVisible = leftPostLandmark[2] != 0;
 			if (landmarkFilter.getSize() > 0 || landmarkVisible)
 			{
 				if (!landmarkVisible)
@@ -165,7 +165,7 @@ void Autonomous::autonomyIter()
 				{
 					// transform and add the new data to the filter
 					transform_t invTransform = toTransform(pose).inverse();
-					point_t landmarkMapSpace = invTransform * firstLandmark;
+					point_t landmarkMapSpace = invTransform * leftPostLandmark;
 					// the filtering is done on the target in map space to reduce any phase lag
 					// caused by filtering
 					driveTarget = point_tToPointXY(landmarkFilter.get(landmarkMapSpace));
@@ -192,17 +192,17 @@ void Autonomous::autonomyIter()
 double Autonomous::pathDirection(const points_t &lidar, const pose_t &gpsPose)
 {
 	double dtheta;
-	if (lidar.empty())
-	{
+	//if (lidar.empty())
+	//{
 		dtheta = angleToTarget(gpsPose);
-	}
-	else
-	{
-		const std::vector<PointXY> &ref = points_tToPointXYs(lidar);
-		PointXY direction = pather.getPath(ref, (float)gpsPose(0), (float)gpsPose(1), target);
-		float theta = std::atan2(direction.y, direction.x);
-		dtheta = static_cast<double>(theta) - gpsPose(2);
-	}
+	//}
+	//else
+	//{
+	//	const std::vector<PointXY> &ref = points_tToPointXYs(lidar);
+	//	PointXY direction = pather.getPath(ref, (float)gpsPose(0), (float)gpsPose(1), target);
+	//	float theta = std::atan2(direction.y, direction.x);
+	//	dtheta = static_cast<double>(theta) - gpsPose(2);
+	//}
 	return dtheta;
 }
 
@@ -272,8 +272,8 @@ std::pair<float, float> Autonomous::stateTurn(float currHeading,
 		else
 		{ // calculate angle to obstacle
 			PointXY robotPos = worldData->getGPS();
-			float x = target.x - robotPos.x;
-			float y = target.y - robotPos.y;
+			float x = target.approx_GPS(0) - robotPos.x;
+			float y = target.approx_GPS(1) - robotPos.y;
 			targetHeading = atan2f(y, x) * (180 / PI);
 			targetHeading = 360 - targetHeading + 90;
 			rightTurn = true; // next turn will turn right
@@ -305,5 +305,5 @@ std::pair<float, float> Autonomous::stateBackwards(float currHeading,
 
 PointXY Autonomous::getTarget()
 {
-	return target;
+	return PointXY { (float)target.approx_GPS(0), (float)target.approx_GPS(1) };
 }

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -17,8 +17,8 @@
 class Autonomous
 {
 public:
-	explicit Autonomous(PointXY target, double controlHz);
-	Autonomous(PointXY target, double controlHz, const pose_t &startPose);
+	explicit Autonomous(const URCLeg &target, double controlHz);
+	Autonomous(const URCLeg &target, double controlHz, const pose_t &startPose);
 	// Returns a pair of floats, in heading, speed
 	// Accepts current heading of the robot as parameter
 	std::pair<float, float> getDirections(float currHeading);
@@ -28,7 +28,7 @@ public:
 	void autonomyIter();
 
 private:
-	PointXY target;
+	URCLeg target;
 	PoseEstimator poseEstimator;
 	RollingAvgFilter<5,3> landmarkFilter;
 	bool calibrated = false;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -28,8 +28,8 @@ int main(int argc, char **argv)
     CANPacket packet;
     // Target location for autonomous navigation
     // Eventually this will be set by communcation from the base station
-    PointXY target { 3.14, 2.71 };
-    Autonomous autonomous(target, CONTROL_HZ);
+    int urc_leg = 1;
+    Autonomous autonomous(getLeg(urc_leg), CONTROL_HZ);
     char buffer[MAXLINE];
     struct timeval tp0, tp_start;
     for(;;)

--- a/src/SimpleAutonomousTester.cpp
+++ b/src/SimpleAutonomousTester.cpp
@@ -1,6 +1,7 @@
 #include "FakeMap.h"
 #include "Autonomous.h"
 #include "WorldData.h"
+#include "simulator/utils.h"
 #include <catch2/catch.hpp>
 #include <future>
 #include <thread>
@@ -9,10 +10,9 @@ constexpr double CONTROL_HZ = 10.0;
 
 TEST_CASE("full autonomous", "[autonomous]")
 {
-    PointXY p;
-    p.x = -10;
-    p.y = 10;
-    Autonomous autonomous(p, CONTROL_HZ);
+    point_t gps_target {-10, 10, 1};
+    URCLeg leg {0, 0, gps_target};
+    Autonomous autonomous(leg, CONTROL_HZ);
     auto fm = std::make_shared<FakeMap>(autonomous);
     fm->addObstacle(PointXY{-5, 5}, PointXY{2, 5});
     fm->addObstacle(PointXY{-9, 7}, PointXY{-5, 6});
@@ -26,10 +26,9 @@ TEST_CASE("full autonomous", "[autonomous]")
 
 TEST_CASE("target at start, no obstacles", "[autonomous]")
 {
-    PointXY p;
-    p.x = 0;
-    p.y = 0;
-    Autonomous autonomous(p, CONTROL_HZ);
+    point_t gps_target {0, 0, 1};
+    URCLeg leg {0, 0, gps_target};
+    Autonomous autonomous(leg, CONTROL_HZ);
     auto fm = std::make_shared<FakeMap>(autonomous);
     autonomous.setWorldData(fm);
     REQUIRE(fm->callAutonomous(200));
@@ -40,10 +39,9 @@ TEST_CASE("target at start, no obstacles", "[autonomous]")
 
 TEST_CASE("robot boxed in, should timeout", "[autonomous]")
 {
-    PointXY p;
-    p.x = 5;
-    p.y = 5;
-    Autonomous autonomous(p, CONTROL_HZ);
+    point_t gps_target {5, 5, 1};
+    URCLeg leg {0, 0, gps_target};
+    Autonomous autonomous(leg, CONTROL_HZ);
     auto fm = std::make_shared<FakeMap>(autonomous);
     autonomous.setWorldData(fm);
     fm->addObstacle(PointXY{-2, 2}, PointXY{2, 2});
@@ -58,10 +56,9 @@ TEST_CASE("robot boxed in, should timeout", "[autonomous]")
 
 TEST_CASE("long line obstacle", "[autonomous]")
 {
-    PointXY p;
-    p.x = 0;
-    p.y = 10;
-    Autonomous autonomous(p, CONTROL_HZ);
+    point_t gps_target {0, 10, 1};
+    URCLeg leg {0, 0, gps_target};
+    Autonomous autonomous(leg, CONTROL_HZ);
     auto fm = std::make_shared<FakeMap>(autonomous);
     autonomous.setWorldData(fm);
     fm->addObstacle(PointXY{-10, 3}, PointXY{10, 3});


### PR DESCRIPTION
Using URCLeg instead is important, because we also need to know when the
AR tag is visible to the cameras.

I tested this using the `getLeg(0)` instead of `getLeg(1)` and it works great!