### PR TITLE
Implement A* planning for obstacle avoidance

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -6,19 +6,26 @@
 
 #include "Globals.h"
 #include "simulator/world_interface.h"
+#include "simulator/constants.h"
 
 constexpr float PI = M_PI;
 constexpr double KP_ANGLE = 2;
 constexpr double DRIVE_SPEED = 8;
 
+const transform_t VIZ_BASE_TF = toTransform({NavSim::DEFAULT_WINDOW_CENTER_X,NavSim::DEFAULT_WINDOW_CENTER_Y,M_PI/2});
 
 Autonomous::Autonomous(const URCLeg &_target, double controlHz)
-	: target(_target),
+	: viz_window("Planning visualization"),
+		target(_target),
 		poseEstimator({0.8, 0.8, 0.6}, {2, 2, PI / 24}, 1.0 / controlHz),
 		calibrated(false),
 		calibrationPoses({}),
 		landmarkFilter(),
-		state(NavState::INIT)
+		state(NavState::INIT),
+		clock_counter(0),
+		plan(0,2),
+		plan_base({0,0,0}),
+		plan_idx(0)
 {
 }
 
@@ -34,6 +41,14 @@ double dist(const pose_t &p1, const pose_t &p2, double theta_weight)
 	pose_t diff = p1 - p2;
 	diff(2) *= theta_weight;
 	return diff.norm();
+}
+
+void Autonomous::drawPose(pose_t &pose, pose_t &current_pose, sf::Color c)
+{
+	// Both poses are given in the same frame. (usually GPS frame)
+	// `current_pose` is the current location of the robot, `pose` is the pose we wish to draw
+	transform_t inv_curr = toTransform(current_pose).inverse();
+	viz_window.drawRobot(toTransform(pose) * inv_curr * VIZ_BASE_TF, c);
 }
 
 bool Autonomous::arrived(const pose_t &pose) const
@@ -183,6 +198,52 @@ void Autonomous::autonomyIter()
 			}
 		}
 
+		const points_t lidar_scan = readLidarScan();
+		bool should_replan = ((clock_counter++) % 20 == 0); // TODO make this configurable
+		if (should_replan) {
+			plan_base = pose;
+			plan_idx = 0;
+			point_t point_t_goal;
+			point_t_goal.topRows(2) = driveTarget.topRows(2);
+			point_t_goal(2) = 1.0;
+			point_t_goal = toTransform(pose) * point_t_goal;
+			double goal_radius = 2.0;
+			plan = getPlan(lidar_scan, point_t_goal, goal_radius);
+		}
+
+		int c;
+		while ((c = viz_window.pollWindowEvent()) != -1) {}
+		transform_t curr_odom = readOdom();
+		viz_window.drawPoints(transformReadings(lidar_scan, VIZ_BASE_TF), sf::Color::Red, 3);
+		drawPose(pose, pose, sf::Color::Black);
+
+		int plan_size = plan.rows();
+		if (plan_size == 0 && dist(driveTarget, pose, 1.0) < 2.0) {
+			// We're probably within planning resolution of the goal,
+			// so using the goal as the drive target makes sense.
+		} else {
+			// Roll out the plan until we find a target pose a certain distance in front
+			// of the robot. (This code also handles visualizing the plan.)
+			pose_t plan_pose = plan_base;
+			drawPose(plan_pose, pose, sf::Color::Red);
+			bool found_target = false;
+			for (int i = 0; i < plan_size; i++) {
+				action_t action = plan.row(i);
+				plan_pose(2) += action(0);
+				plan_pose(0) += action(1) * cos(plan_pose(2));
+				plan_pose(1) += action(1) * sin(plan_pose(2));
+				if (i >= plan_idx && !found_target && dist(plan_pose, pose, 1.0) > 5.0) {
+					found_target = true;
+					plan_idx = i;
+					driveTarget = plan_pose;
+					drawPose(plan_pose, pose, sf::Color::Blue);
+				} else {
+					drawPose(plan_pose, pose, sf::Color::Red);
+				}
+			}
+		}
+		viz_window.display();
+
 		double d = dist(driveTarget, pose, 0);
 		// There's an overlap where either state might apply, to prevent rapidly switching
 		// back and forth between these two states.
@@ -200,10 +261,6 @@ void Autonomous::autonomyIter()
 		{
 			setCmdVel(thetaVel, driveSpeed);
 			poseEstimator.predict(thetaVel, driveSpeed);
-
-			std::cout << "ThetaVel: " << thetaVel << " DriveVel: " << driveSpeed
-						<< " thetaErr: " << thetaErr << " targetX: " << driveTarget(0)
-						<< " targetY: " << driveTarget(1) << std::endl;
 		}
 	}
 }

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -211,9 +211,7 @@ void Autonomous::autonomyIter()
 			plan = getPlan(lidar_scan, point_t_goal, goal_radius);
 		}
 
-		int c;
-		while ((c = viz_window.pollWindowEvent()) != -1) {}
-		transform_t curr_odom = readOdom();
+		while (viz_window.pollWindowEvent() != -1) {}
 		viz_window.drawPoints(transformReadings(lidar_scan, VIZ_BASE_TF), sf::Color::Red, 3);
 		drawPose(pose, pose, sf::Color::Black);
 

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -32,17 +32,17 @@ public:
 	void autonomyIter();
 
 private:
-  MyWindow viz_window;
+	MyWindow viz_window;
 	URCLeg target;
 	PoseEstimator poseEstimator;
 	bool calibrated = false;
 	std::vector<pose_t> calibrationPoses{};
 	RollingAvgFilter<5,3> landmarkFilter;
 	NavState state;
-  int clock_counter;
-  plan_t plan;
-  pose_t plan_base;
-  int plan_idx;
+	int clock_counter;
+	plan_t plan;
+	pose_t plan_base;
+	int plan_idx;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);
@@ -51,7 +51,7 @@ private:
 
 	double getLinearVel(const pose_t &target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &target, const pose_t &pose, double &thetaErr) const;
-  void drawPose(pose_t &pose, pose_t &current_pose, sf::Color c);
+	void drawPose(pose_t &pose, pose_t &current_pose, sf::Color c);
 
 	ObstacleMap obsMap;
 	Pather2 pather;

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -11,7 +11,9 @@
 #include "filters/PoseEstimator.h"
 #include "filters/RollingAvgFilter.h"
 #include "lidar/PointCloudProcessing.h"
+#include "simulator/graphics.h"
 #include "simulator/utils.h"
+#include "simulator/plan.h"
 
 enum NavState {
 	INIT,
@@ -30,12 +32,17 @@ public:
 	void autonomyIter();
 
 private:
+  MyWindow viz_window;
 	URCLeg target;
 	PoseEstimator poseEstimator;
 	bool calibrated = false;
 	std::vector<pose_t> calibrationPoses{};
 	RollingAvgFilter<5,3> landmarkFilter;
 	NavState state;
+  int clock_counter;
+  plan_t plan;
+  pose_t plan_base;
+  int plan_idx;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);
@@ -44,6 +51,7 @@ private:
 
 	double getLinearVel(const pose_t &target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &target, const pose_t &pose, double &thetaErr) const;
+  void drawPose(pose_t &pose, pose_t &current_pose, sf::Color c);
 
 	ObstacleMap obsMap;
 	Pather2 pather;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND RoverCommonTest
   Autonomous.cpp
   Util.cpp
   simulator/utils.cpp
+  simulator/plan.cpp
   filters/PoseEstimator.cpp
   )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND RoverCommonTest
   Util.cpp
   simulator/utils.cpp
   simulator/plan.cpp
+  simulator/graphics.cpp
   filters/PoseEstimator.cpp
   )
 
@@ -57,7 +58,6 @@ add_executable(RoverSim
   #simulator/plan.cpp
   #simulator/search.cpp
   simulator/utils.cpp
-  simulator/graphics.cpp
   simulator/simulator_world.cpp
   simulator/world.cpp)
 
@@ -114,7 +114,7 @@ add_executable(visualizer_test
   Pathfinding/ObstacleMap.cpp
   )
 
-list(APPEND simulator_libs
+list(APPEND sfml_libs
   sfml-graphics sfml-window sfml-system pthread Eigen3::Eigen)
 
 # My IDE kept yelling at me until I added these lines. I'm still able to build on the VM so I think it doesn't break anything
@@ -124,9 +124,12 @@ include_directories(${EIGEN3_INCLUDE_DIR})
 target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(Rover ${OpenCV_LIBS})
+target_link_libraries(RoverNoCAN ${sfml_libs})
+target_link_libraries(Rover ${sfml_libs})
 target_link_libraries(visualizer_test ${OpenCV_LIBS})
-target_link_libraries(RoverSim ${OpenCV_LIBS} ${simulator_libs})
-target_link_libraries(simulator_navigation_demo ${simulator_libs})
+target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs})
+target_link_libraries(simulator_navigation_demo ${sfml_libs})
+target_link_libraries(tests ${sfml_libs})
 
 include(CTest)
 include(Catch)

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     CANPacket packet;
     // Target location for autonomous navigation
     // Eventually this will be set by communcation from the base station
-    int urc_leg = 2;
+    int urc_leg = 5;
     Autonomous autonomous(getLeg(urc_leg), CONTROL_HZ);
     char buffer[MAXLINE];
     struct timeval tp0, tp_start;
@@ -49,6 +49,8 @@ int main(int argc, char **argv)
         long desiredUsecs = 1000 * 1000 / CONTROL_HZ;
         if (desiredUsecs - elapsedUsecs > 0) {
             usleep(desiredUsecs - elapsedUsecs);
+        } else {
+            std::cout << "Can't keep up with control frequency! Desired " << desiredUsecs/1000 << " elapsed " << elapsedUsecs/1000 << std::endl;
         }
     }
     return 0;


### PR DESCRIPTION
    This also implements showing a visualization window so we can visualize
    what the rover is planning to do.
    
    The current code replans once every two seconds and in the mean time
    does a hacky kind of pure pursuit.
    
    Due to the infrequent replanning, sometimes the rover crashes before
    replanning is triggered. In a future PR, we should fix this by verifying
    the plan at each timestep using the most recent lidar scans.