### PR TITLE
Fix bug in RollingAvgFilter

### DIFF
--- a/src/filters/RollingAvgFilter.h
+++ b/src/filters/RollingAvgFilter.h
@@ -90,6 +90,6 @@ public:
 
 private:
 	Eigen::Matrix<double, numDims, numPoints> data; // represents a circular buffer
-	int size;
-	int index;
+	int size = 0;
+	int index = 0;
 };


### PR DESCRIPTION
While writing unit tests, I found this bug in the rolling average filter. The size and index fields are not initialized on startup, so they have arbitrary values at the beginning, causing the filter to break.

This is pretty easily fixed by initializing them to 0.