### PR TITLE
hopefully the last fix to RollingAvgFilter

### DIFF
--- a/src/filters/RollingAvgFilter.h
+++ b/src/filters/RollingAvgFilter.h
@@ -17,7 +17,7 @@ public:
 	 */
 	Eigen::Matrix<double, numDims, 1> get() const
 	{
-		Eigen::Matrix<double, numDims, 1> ret;
+		Eigen::Matrix<double, numDims, 1> ret = Eigen::Matrix<double, numDims, 1>::Zero();
 		if (size == 0)
 		{
 			return ret;
@@ -89,7 +89,7 @@ public:
 	}
 
 private:
-	Eigen::Matrix<double, numDims, numPoints> data; // represents a circular buffer
+	Eigen::Matrix<double, numDims, numPoints> data; // ring buffer, starts with garbage data
 	int size = 0;
 	int index = 0;
 };

--- a/src/filters/RollingAvgFilter.h
+++ b/src/filters/RollingAvgFilter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <vector>
 
 /**
  * Implements a rolling average filter of the specified type. Can only use double vectors.


### PR DESCRIPTION
It seems that my environment *usually* zero-initialized vectors, but this isn't guaranteed or enforced, so it would randomly and infrequently fail unit tests.

Explicitly initializing the vector used to sum the data points to zero fixed this. I've tested it many times since, so hopefully this should be ironed out.