### PR TITLE
Spiral search pattern

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -23,7 +23,7 @@ const transform_t VIZ_BASE_TF = toTransform({NavSim::DEFAULT_WINDOW_CENTER_X,Nav
 Autonomous::Autonomous(const URCLeg &_target, double controlHz)
 	: viz_window("Planning visualization"),
 		target(_target),
-		driveTarget({target.approx_GPS(0), target.approx_GPS(1), 0.0}),
+		searchTarget({target.approx_GPS(0) - PI, target.approx_GPS(1), -PI / 4}),
 		poseEstimator({1.5, 1.5}, gpsStdDev, Constants::WHEEL_BASE, 1.0 / controlHz),
 		calibrated(false),
 		calibrationPoses({}),
@@ -66,14 +66,20 @@ void Autonomous::drawPose(pose_t &pose, pose_t &current_pose, sf::Color c)
 
 bool Autonomous::arrived(const pose_t &pose) const
 {
-	return landmarkFilter.getSize() > 0 && dist(pose, driveTarget, 1.0) < 0.5;
+	if (landmarkFilter.getSize() == 0)
+	{
+		return false;
+	}
+	pose_t target = getTargetPose();
+	target.topRows(2) = landmarkFilter.get().topRows(2);
+	return dist(pose, target, 1.0) < 0.5;
 }
 
 double Autonomous::angleToTarget(const pose_t &gpsPose) const
 {
-	float dy = driveTarget(1) - (float)gpsPose(1);
-	float dx = driveTarget(0) - (float)gpsPose(0);
-	double theta = atan2(dy, dx);
+	float dy = target.approx_GPS(1) - (float)gpsPose(1);
+	float dx = target.approx_GPS(0) - (float)gpsPose(0);
+	double theta = std::atan2(dy, dx);
 	return theta - gpsPose(2);
 }
 
@@ -185,6 +191,8 @@ void Autonomous::autonomyIter()
 	}
 	else
 	{
+		pose_t driveTarget = getTargetPose();
+
 		// if we have some existing data or new data, set the target using the landmark
 		// data
 		bool landmarkVisible = leftPostLandmark(2) != 0;
@@ -211,6 +219,12 @@ void Autonomous::autonomyIter()
 				// Currently in a search pattern and landmark has been seen, can exit search
 				state = NavState::INIT;
 			}
+		}
+
+		// If we are in a search pattern, set the drive target to the next search point
+		if (state == NavState::SEARCH_PATTERN)
+		{
+			driveTarget = searchTarget;
 		}
 
 		const points_t lidar_scan = readLidarScan();
@@ -258,25 +272,25 @@ void Autonomous::autonomyIter()
 		viz_window.display();
 
 		double d = dist(driveTarget, pose, 0);
-		if (d < 0.2 && state == NavState::SEARCH_PATTERN) {
-			// Current search point has been reached, set the drive target to the
+		if (state == NavState::SEARCH_PATTERN && dist(searchTarget, pose, 0) < 0.5)
+		{
+			// Current search point has been reached, set the search target to the
 			// next point in the search pattern
-			driveTarget -= target.approx_GPS;
-			double radius = hypot(driveTarget(0), driveTarget(1));
+			searchTarget -= target.approx_GPS;
+			double radius = hypot(searchTarget(0), searchTarget(1));
 			double scale = (radius + SEARCH_THETA_INCREMENT) / radius;
-			driveTarget.topRows(2) = searchPatternTransform * driveTarget.topRows(2) * scale;
-			driveTarget += target.approx_GPS;
-			driveTarget(2) += SEARCH_THETA_INCREMENT;
-			if (driveTarget(2) > PI)
+			searchTarget.topRows(2) = searchPatternTransform * searchTarget.topRows(2) * scale;
+			searchTarget += target.approx_GPS;
+			searchTarget(2) += SEARCH_THETA_INCREMENT;
+			if (searchTarget(2) > PI)
 			{
-				driveTarget(2) -= 2 * PI;
+				searchTarget(2) -= 2 * PI;
 			}
 		}
-		if (d < 0.2 && landmarkFilter.getSize() == 0 && !landmarkVisible)
+		if (dist(target.approx_GPS, pose, 0) < 0.2 && landmarkFilter.getSize() == 0 && !landmarkVisible)
 		{
 			// Close to GPS target but no landmark in sight, should use search pattern
 			state = NavState::SEARCH_PATTERN;
-			driveTarget = {target.approx_GPS(0) - PI, target.approx_GPS(1), -PI / 2};
 		}
 		// There's an overlap where either state might apply, to prevent rapidly switching
 		// back and forth between these two states.
@@ -311,5 +325,6 @@ double Autonomous::pathDirection(const points_t &lidar, const pose_t &gpsPose)
 
 pose_t Autonomous::getTargetPose() const
 {
-	return driveTarget;
+	pose_t ret{target.approx_GPS(0), target.approx_GPS(1), 0.0};
+	return ret;
 }

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -35,7 +35,7 @@ public:
 private:
 	MyWindow viz_window;
 	URCLeg target;
-	pose_t driveTarget;
+	pose_t searchTarget;
 	PoseEstimator poseEstimator;
 	bool calibrated = false;
 	std::vector<pose_t> calibrationPoses{};

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -35,7 +35,7 @@ public:
 private:
 	MyWindow viz_window;
 	URCLeg target;
-	pose_t searchTarget;
+	pose_t search_target;
 	PoseEstimator poseEstimator;
 	bool calibrated = false;
 	std::vector<pose_t> calibrationPoses{};
@@ -46,8 +46,8 @@ private:
 	pose_t plan_base;
 	int plan_idx;
 	bool should_replan;
-	double searchThetaIncrement;
-	bool alreadyArrived;
+	double search_theta_increment;
+	bool already_arrived;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -45,7 +45,9 @@ private:
 	plan_t plan;
 	pose_t plan_base;
 	int plan_idx;
+	bool should_replan;
 	double searchThetaIncrement;
+	bool alreadyArrived;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -45,6 +45,7 @@ private:
 	plan_t plan;
 	pose_t plan_base;
 	int plan_idx;
+	double searchThetaIncrement;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -35,6 +35,7 @@ public:
 private:
 	MyWindow viz_window;
 	URCLeg target;
+	pose_t driveTarget;
 	PoseEstimator poseEstimator;
 	bool calibrated = false;
 	std::vector<pose_t> calibrationPoses{};
@@ -44,7 +45,6 @@ private:
 	plan_t plan;
 	pose_t plan_base;
 	int plan_idx;
-	float searchPatternTheta;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -17,7 +17,8 @@
 
 enum NavState {
 	INIT,
-	NEAR_TARGET_POSE
+	NEAR_TARGET_POSE,
+	SEARCH_PATTERN
 };
 
 class Autonomous
@@ -43,6 +44,7 @@ private:
 	plan_t plan;
 	pose_t plan_base;
 	int plan_idx;
+	float searchPatternTheta;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);


### PR DESCRIPTION
Adds a spiral search pattern for when the rover arrives at the provided GPS coordinates but cannot see the target landmark. The rover also replans more often so as to speed up the search. The `arrived` function has also been updated to only return true when the rover has reached the landmark post.

The spiral search pattern roughly follows the polar curve r = θ starting at θ = π. The rover moves along this curve by navigating between points on the curve with θ intervals of `search_theta_increment`. `search_theta_increment` decreases as the rover moves further away from the center, so that the spiral shape is maintained. The current A* planning is used to navigate between points.

The search currently does not try to avoid obstacles, and points can be placed inside obstacles where they cannot be reached. This is something we should address in a later commit.