### PR TITLE
Explicitly zero-init vector when calibrating

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -77,7 +77,7 @@ bool calibratePeriodic(std::vector<pose_t> &poses, const pose_t &pose, pose_t &o
 	poses.push_back(pose);
 	if (poses.size() == numSamples)
 	{
-		pose_t sum;
+		pose_t sum = pose_t::Zero();
 		for (const pose_t &p : poses)
 		{
 			sum += p;


### PR DESCRIPTION
More of the same mistake where I didn't explicitly zero-init a vector. It seems to work most of the time since it was usually zero-initialized but that's not guaranteed.

I've grepped through the rest of the project and I'm pretty sure there are no other occurrences of this mistake.