### PR TITLE
ROS2 Plan Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ CMake, or Homebrew for Mac users.
 Execute the following commands in your terminal:
 1. `git clone https://github.com/catchorg/Catch2.git`
 2. `cd Catch2`
-3. `git checkout v2.13.3`
+3. `git checkout v2.13.4`
 4. `mkdir build`
 5. `cd build`
 6. `cmake -H.. -DBUILD_TESTING=OFF`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,53 @@ sudo make install
 Follow instructions in `src/simulator/README.md`, or just execute the commands
 from `tests-docker-action/entrypoint.sh`.
 
+## Install ROS (planning visualization)
+
+### On Ubuntu (Including Windows Subsystem for Linux)
+
+Make sure you have a locale which supports UTF-8:
+
+```bash
+locale  # check for UTF-8
+```
+
+If your locale does not support UTF-8, run the following commands:
+
+```bash
+sudo apt update && sudo apt install locales
+sudo locale-gen en_US en_US.UTF-8
+sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+locale  # verify settings
+```
+
+Set up the ROS apt repositories:
+
+```bash
+sudo apt update && sudo apt install curl gnupg2 lsb-release
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo apt update
+```
+
+Ubuntu 18.04 and 20.04 support different ROS distributions, so replace `<version>` in the commands below with the appropriate version for your system.
+
+18.04: `dashing`  
+20.04: `foxy`  
+
+```bash
+sudo apt install ros-<version>-ros-base
+source /opt/ros/<version>/setup.bash
+echo "source /opt/ros/<version>/setup.bash" >> ~/.bashrc
+```
+
+### On other systems (not tested)
+
+Follow the instructions here: https://index.ros.org/doc/ros2/Installation/Foxy/
+
+If your system doesn't support ROS Foxy, install ROS Dashing by following the instructions here: https://index.ros.org/doc/ros2/Installation/Dashing/
+
 ## Setup Project Repository
 This step will require you to have CMake and Git. If you've followed the above
 OpenCV setup instructions, you should have these installed already. The

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -298,6 +298,9 @@ void Autonomous::autonomyIter()
 			publish(point, lidar_pub);
 		}
 
+		// Send message that all lidar points have been sent
+		publish({INFINITY, INFINITY, INFINITY}, lidar_pub);
+
 		const pose_t curr_pose_transformed = poseToDraw(pose, pose);
 		publish(curr_pose_transformed, curr_pose_pub);
 
@@ -338,6 +341,8 @@ void Autonomous::autonomyIter()
 					publish(curr_plan_transformed, plan_pub);
 				}
 			}
+			// Send message that all plan poses have been sent
+			publish({INFINITY, INFINITY, INFINITY}, plan_pub);
 		}
 		// viz_window.display();
 

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -23,7 +23,7 @@ enum NavState {
 	SEARCH_PATTERN
 };
 
-class Autonomous
+class Autonomous : rclcpp::Node
 {
 public:
 	explicit Autonomous(const URCLeg &target, double controlHz);
@@ -49,7 +49,6 @@ private:
 	int plan_idx;
 	double search_theta_increment;
 	bool already_arrived;
-	rclcpp::Node::SharedPtr node;
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr plan_pub;
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr curr_pose_pub;
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr next_pose_pub;

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/point.hpp>
 
 #include "Pathfinding/ObstacleMap.h"
 #include "Pathfinding/Pather2.h"
@@ -48,6 +50,11 @@ private:
 	bool should_replan;
 	double search_theta_increment;
 	bool already_arrived;
+	rclcpp::Node::SharedPtr node;
+	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr plan_pub;
+	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr curr_pose_pub;
+	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr next_pose_pub;
+	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr lidar_pub;
 
 	// determine direction for robot at any given iteration
 	double pathDirection(const points_t &lidar, const pose_t &gpsPose);

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -35,7 +35,6 @@ public:
 	void autonomyIter();
 
 private:
-	// MyWindow viz_window;
 	URCLeg target;
 	pose_t search_target;
 	PoseEstimator poseEstimator;
@@ -63,7 +62,8 @@ private:
 
 	double getLinearVel(const pose_t &target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &target, const pose_t &pose, double &thetaErr) const;
-	pose_t poseToDraw(pose_t &pose, pose_t &current_pose);
+	pose_t poseToDraw(pose_t &pose, pose_t &current_pose) const;
+	void publish(Eigen::Vector3d pose, rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr &publisher) const;
 
 	ObstacleMap obsMap;
 	Pather2 pather;

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -33,7 +33,7 @@ public:
 	void autonomyIter();
 
 private:
-	MyWindow viz_window;
+	// MyWindow viz_window;
 	URCLeg target;
 	pose_t search_target;
 	PoseEstimator poseEstimator;
@@ -56,7 +56,7 @@ private:
 
 	double getLinearVel(const pose_t &target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &target, const pose_t &pose, double &thetaErr) const;
-	void drawPose(pose_t &pose, pose_t &current_pose, sf::Color c);
+	pose_t poseToDraw(pose_t &pose, pose_t &current_pose);
 
 	ObstacleMap obsMap;
 	Pather2 pather;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,14 @@ add_executable(RoverSim
   simulator/simulator_world.cpp
   simulator/world.cpp)
 
+add_executable(PlanViz
+  ${RoverCommonTest}
+  PlanViz.cpp
+  Networking/CANStubs.cpp
+  simulator/simulator_world.cpp
+  simulator/world.cpp
+  Networking/Network.cpp)
+
 add_executable(tests
   ${RoverCommonTest}
   Tests.cpp
@@ -143,6 +151,7 @@ target_link_libraries(visualizer_test ${OpenCV_LIBS})
 target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 target_link_libraries(simulator_navigation_demo ${sfml_libs})
 target_link_libraries(tests ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
+target_link_libraries(PlanViz ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 
 include(CTest)
 include(Catch)
@@ -172,6 +181,7 @@ add_executable(FakeCANBoard
 set_property(TARGET Rover PROPERTY CXX_STANDARD 14)
 set_property(TARGET RoverNoCAN PROPERTY CXX_STANDARD 14)
 set_property(TARGET RoverSim PROPERTY CXX_STANDARD 14)
+set_property(TARGET PlanViz PROPERTY CXX_STANDARD 14)
 set_property(TARGET tests PROPERTY CXX_STANDARD 14)
 set_property(TARGET lidar_vis PROPERTY CXX_STANDARD 14)
 set_property(TARGET lidarOnlyTest PROPERTY CXX_STANDARD 14)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
+cmake_policy(SET CMP0057 NEW)
 set(CMAKE_CXX_STANDARD 11) # For the json library
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -6,6 +7,11 @@ project(Rover LANGUAGES CXX C)
 
 find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED NO_MODULE)
+
+find_package(rclcpp REQUIRED)
+find_package(geometry_msgs REQUIRED)
+include_directories(${rclcpp_INCLUDE_DIRS})
+include_directories(${geometry_msgs_INCLUDE_DIRS})
 
 add_definitions(-DCHIP_TYPE=CHIP_TYPE_TEMPLATE)
 
@@ -130,13 +136,13 @@ include_directories(${EIGEN3_INCLUDE_DIR})
 
 target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})
-target_link_libraries(Rover ${OpenCV_LIBS})
-target_link_libraries(RoverNoCAN ${sfml_libs})
+target_link_libraries(Rover ${OpenCV_LIBS} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
+target_link_libraries(RoverNoCAN ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 target_link_libraries(Rover ${sfml_libs})
 target_link_libraries(visualizer_test ${OpenCV_LIBS})
-target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs})
+target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 target_link_libraries(simulator_navigation_demo ${sfml_libs})
-target_link_libraries(tests ${sfml_libs})
+target_link_libraries(tests ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 
 include(CTest)
 include(Catch)
@@ -164,5 +170,8 @@ add_executable(FakeCANBoard
   HindsightCAN/PortTemplate.c)
 
 set_property(TARGET Rover PROPERTY CXX_STANDARD 14)
+set_property(TARGET RoverNoCAN PROPERTY CXX_STANDARD 14)
+set_property(TARGET RoverSim PROPERTY CXX_STANDARD 14)
+set_property(TARGET tests PROPERTY CXX_STANDARD 14)
 set_property(TARGET lidar_vis PROPERTY CXX_STANDARD 14)
 set_property(TARGET lidarOnlyTest PROPERTY CXX_STANDARD 14)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,12 +70,9 @@ add_executable(RoverSim
   simulator/world.cpp)
 
 add_executable(PlanViz
-  ${RoverCommonTest}
   PlanViz.cpp
-  Networking/CANStubs.cpp
-  simulator/simulator_world.cpp
-  simulator/world.cpp
-  Networking/Network.cpp)
+  simulator/utils.cpp
+  simulator/graphics.cpp)
 
 add_executable(tests
   ${RoverCommonTest}

--- a/src/PlanViz.cpp
+++ b/src/PlanViz.cpp
@@ -1,0 +1,120 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/point.hpp>
+
+#include "simulator/graphics.h"
+#include "simulator/utils.h"
+
+using subscription = rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr;
+using std::placeholders::_1;
+
+using namespace std;
+
+class PlanViz : public rclcpp::Node
+{
+public:
+	PlanViz()
+		: Node("plan_visualization"),
+		  curr_pose({0,0,0}),
+		  next_pose({0,0,0}),
+		  lidar_scan({}),
+		  plan_poses({}),
+		  viz_window("Planning visualization")
+	{
+		plan_sub = this->create_subscription<geometry_msgs::msg::Point>("plan_viz", 10, std::bind(&PlanViz::plan_callback, this, _1));
+		curr_pose_sub = this->create_subscription<geometry_msgs::msg::Point>("current_pose", 10, std::bind(&PlanViz::curr_pose_callback, this, _1));
+		next_pose_sub = this->create_subscription<geometry_msgs::msg::Point>("next_pose", 10, std::bind(&PlanViz::next_pose_callback, this, _1));
+		lidar_sub = this->create_subscription<geometry_msgs::msg::Point>("lidar_scan", 10, std::bind(&PlanViz::lidar_callback, this, _1));
+	}
+
+private:
+	void curr_pose_callback(const geometry_msgs::msg::Point::SharedPtr message)
+	{
+		curr_pose = {message->x, message->y, message->z};
+		redraw();
+	}
+
+	void next_pose_callback(const geometry_msgs::msg::Point::SharedPtr message)
+	{
+		next_pose = {message->x, message->y, message->z};
+		redraw();
+	}
+
+	void plan_callback(const geometry_msgs::msg::Point::SharedPtr message)
+	{
+		if (isnan(message->x) && isnan(message->y) && isnan(message->z))
+		{
+			plan_poses.clear();
+		}
+		else if (isinf(message->x) && isinf(message->y) && isinf(message->z))
+		{
+			redraw();
+		}
+		else
+		{
+			plan_poses.push_back({message->x, message->y, message->z});
+		}
+	}
+
+	void lidar_callback(const geometry_msgs::msg::Point::SharedPtr message)
+	{
+		if(isnan(message->x) && isnan(message->y) && isnan(message->z))
+		{
+			lidar_scan.clear();
+		}
+		else if (isinf(message->x) && isinf(message->y) && isinf(message->z))
+		{
+			redraw();
+		}
+		else
+		{
+			lidar_scan.push_back({message->x, message->y, message->z});
+		}
+	}
+
+	void redraw()
+	{
+		viz_window.drawRobot(toTransform(curr_pose), sf::Color::Black);
+		viz_window.drawRobot(toTransform(next_pose), sf::Color::Blue);
+		for (pose_t plan_pose: plan_poses)
+		{
+			viz_window.drawRobot(toTransform(plan_pose), sf::Color::Red);
+		}
+		viz_window.drawPoints(lidar_scan, sf::Color::Red, 3);
+		viz_window.display();
+	}
+
+	subscription plan_sub;
+	subscription curr_pose_sub;
+	subscription next_pose_sub;
+	subscription lidar_sub;
+	pose_t curr_pose;
+	pose_t next_pose;
+	points_t lidar_scan;
+	vector<pose_t> plan_poses;
+	MyWindow viz_window;
+};
+
+//void stop(int signum)
+//{
+//	rclcpp::shutdown();
+//	raise(SIGTERM);
+//}
+
+int main(int argc, char **argv)
+{
+//	MyWindow viz_window("Planning visualization");
+
+	// Ctrl+C isn't recognized without this line, rclcpp might override the signal
+	//signal(SIGINT, stop);
+
+	// Initialize ROS without any commandline arguments
+	rclcpp::init(0, nullptr);
+//	rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("visualization");
+//	subscription plan_sub = node->create_subscription<geometry_msgs::msg::Point>("plan_viz", 10);
+//	subscription curr_pose_sub = node->create_subscription<geometry_msgs::msg::Point>("current_pose", 10);
+//	subscription next_pose_sub = node->create_subscription<geometry_msgs::msg::Point>("next_pose", 10);
+//	subscription lidar_sub = node->create_subscription<geometry_msgs::msg::Point>("lidar_scan", 10);
+	rclcpp::spin(std::make_shared<PlanViz>());
+	rclcpp::shutdown();
+	return 0;
+}

--- a/src/PlanViz.cpp
+++ b/src/PlanViz.cpp
@@ -11,28 +11,25 @@ class PlanViz : public rclcpp::Node
 public:
 	PlanViz()
 		: Node("plan_visualization"),
-		  curr_pose({0,0,0}),
-		  next_pose({0,0,0}),
-		  lidar_scan({}),
-		  plan_poses({}),
-		  viz_window("Planning visualization")
+			lidar_scan({}),
+			viz_window("Planning visualization"),
+			plan_sub(this->create_subscription<geometry_msgs::msg::Point>("plan_viz", 100, std::bind(&PlanViz::plan_callback, this, _1))),
+			curr_pose_sub(this->create_subscription<geometry_msgs::msg::Point>("current_pose", 100, std::bind(&PlanViz::curr_pose_callback, this, _1))),
+			next_pose_sub(this->create_subscription<geometry_msgs::msg::Point>("next_pose", 100, std::bind(&PlanViz::next_pose_callback, this, _1))),
+			lidar_sub(this->create_subscription<geometry_msgs::msg::Point>("lidar_scan", 100, std::bind(&PlanViz::lidar_callback, this, _1)))
 	{
-		plan_sub = this->create_subscription<geometry_msgs::msg::Point>("plan_viz", 100, std::bind(&PlanViz::plan_callback, this, _1));
-		curr_pose_sub = this->create_subscription<geometry_msgs::msg::Point>("current_pose", 100, std::bind(&PlanViz::curr_pose_callback, this, _1));
-		next_pose_sub = this->create_subscription<geometry_msgs::msg::Point>("next_pose", 100, std::bind(&PlanViz::next_pose_callback, this, _1));
-		lidar_sub = this->create_subscription<geometry_msgs::msg::Point>("lidar_scan", 100, std::bind(&PlanViz::lidar_callback, this, _1));
 		viz_window.display();
 	}
 
 private:
 	void curr_pose_callback(const geometry_msgs::msg::Point::SharedPtr message)
 	{
-		curr_pose = {message->x, message->y, message->z};
+		viz_window.drawRobot(toTransform({message->x, message->y, message->z}), sf::Color::Black);
 	}
 
 	void next_pose_callback(const geometry_msgs::msg::Point::SharedPtr message)
 	{
-		next_pose = {message->x, message->y, message->z};
+		viz_window.drawRobot(toTransform({message->x, message->y, message->z}), sf::Color::Blue);
 	}
 
 	void lidar_callback(const geometry_msgs::msg::Point::SharedPtr message)
@@ -42,51 +39,25 @@ private:
 
 	void plan_callback(const geometry_msgs::msg::Point::SharedPtr message)
 	{
-		// This function also handles start and end messages
 		if (std::isnan(message->x) && std::isnan(message->y) && std::isnan(message->z))
 		{
-			// Clear data from last visualization
-			lidar_scan.clear();
-			plan_poses.clear();
-			// Reset target pose so it's not shown if it isn't sent
-			next_pose = {NAN, NAN, NAN};
-		}
-		else if (std::isinf(message->x) && std::isinf(message->y) && std::isinf(message->z))
-		{
 			// All data has been received, we can draw the visualization
-			draw();
+			while (viz_window.pollWindowEvent() != -1) {}
+			viz_window.drawPoints(lidar_scan, sf::Color::Red, 3);
+			lidar_scan.clear();
+			viz_window.display();
 		}
 		else
 		{
-			plan_poses.push_back({message->x, message->y, message->z});
+			viz_window.drawRobot(toTransform({message->x, message->y, message->z}), sf::Color::Red);
 		}
-	}
-
-	void draw()
-	{
-		while (viz_window.pollWindowEvent() != -1) {}
-		viz_window.drawRobot(toTransform(curr_pose), sf::Color::Black);
-		// Don't draw target pose if it wasn't sent
-		if (!std::isnan(next_pose(0)) && !std::isnan(next_pose(1)) && !std::isnan(next_pose(2)))
-		{
-			viz_window.drawRobot(toTransform(next_pose), sf::Color::Blue);
-		}
-		for (pose_t plan_pose: plan_poses)
-		{
-			viz_window.drawRobot(toTransform(plan_pose), sf::Color::Red);
-		}
-		viz_window.drawPoints(lidar_scan, sf::Color::Red, 3);
-		viz_window.display();
 	}
 
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr plan_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr curr_pose_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr next_pose_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr lidar_sub;
-	pose_t curr_pose;
-	pose_t next_pose;
 	points_t lidar_scan;
-	std::vector<pose_t> plan_poses;
 	MyWindow viz_window;
 };
 

--- a/src/PlanViz.cpp
+++ b/src/PlanViz.cpp
@@ -53,12 +53,12 @@ private:
 		}
 	}
 
+	points_t lidar_scan;
+	MyWindow viz_window;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr plan_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr curr_pose_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr next_pose_sub;
 	rclcpp::Subscription<geometry_msgs::msg::Point>::SharedPtr lidar_sub;
-	points_t lidar_scan;
-	MyWindow viz_window;
 };
 
 int main(int argc, char **argv)

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <ctime>
+#include <csignal>
 
 #include "CommandLineOptions.h"
 #include "Globals.h"
@@ -18,16 +19,25 @@ void InitializeRover()
     InitializeBaseStationSocket();
 }
 
+void closeSim(int signum)
+{
+	rclcpp::shutdown();
+	raise(SIGTERM);
+}
+
 const double CONTROL_HZ = 10.0;
 
 int main(int argc, char **argv)
 {
     world_interface_init();
+	rclcpp::init(0, nullptr);
+	// Ctrl+C doesn't stop the simulation without this line
+	signal(SIGINT, closeSim);
     Globals::opts = ParseCommandLineOptions(argc, argv);
     InitializeRover();
     CANPacket packet;
     // Target location for autonomous navigation
-    // Eventually this will be set by communcation from the base station
+    // Eventually this will be set by communication from the base station
     int urc_leg = 5;
     Autonomous autonomous(getLeg(urc_leg), CONTROL_HZ);
     char buffer[MAXLINE];

--- a/tests-docker-action/Dockerfile
+++ b/tests-docker-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM uwhuskyrobots/rover-test-deps
+FROM uwhuskyrobots/rover-test-deps-ros
 
 COPY . .
 

--- a/tests-docker-action/entrypoint.sh
+++ b/tests-docker-action/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 git submodule update --init --recursive
 source /opt/ros/foxy/setup.bash
 mkdir ./build

--- a/tests-docker-action/entrypoint.sh
+++ b/tests-docker-action/entrypoint.sh
@@ -1,4 +1,5 @@
 git submodule update --init --recursive
+source /opt/ros/foxy/setup.bash
 mkdir ./build
 cd build
 cmake ../src

--- a/tests-docker-action/rover-test-deps-ros-Dockerfile
+++ b/tests-docker-action/rover-test-deps-ros-Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR "/"
+
+# Run system software update
+RUN apt-get update
+RUN apt-get upgrade -y
+
+# Install system dependencies
+RUN apt-get install -y wget unzip curl gnupg2 lsb-release
+
+################### SFML ###################
+
+RUN apt-get install -y libsfml-dev
+
+################### EIGEN ###################
+
+RUN apt-get install -y libeigen3-dev
+
+################### OPENCV ###################
+
+WORKDIR "/usr/local/share"
+# Install dependencies for OpenCV
+RUN apt-get install -y build-essential
+RUN apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev \
+	libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev \
+	libpng-dev libtiff-dev libdc1394-22-dev
+
+# Download OpenCV tarball
+RUN wget -O /tmp/3.4.7.zip https://github.com/opencv/opencv/archive/3.4.7.zip
+
+# Unpack OpenCV tarball
+RUN unzip /tmp/3.4.7.zip
+
+# Download OpenCV contrib modules
+RUN git clone https://github.com/opencv/opencv_contrib
+WORKDIR "/usr/local/share/opencv_contrib"
+RUN git checkout 3.4.7
+
+# Enable only specific contrib modules
+RUN mkdir enabled_modules
+RUN cp -r modules/aruco enabled_modules/
+WORKDIR "/usr/local/share"
+
+# Configure OpenCV build
+WORKDIR "/usr/local/share/opencv-3.4.7"
+RUN mkdir build
+WORKDIR "/usr/local/share/opencv-3.4.7/build"
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DENABLE_PRECOMPILED_HEADERS=OFF \
+	-DOPENCV_EXTRA_MODULES_PATH=/usr/local/share/opencv_contrib/enabled_modules/ \
+	-DBUILD_OPENEXR=OFF -DWITH_OPENEXR=OFF -DBUILD_PROTOBUF=OFF \
+	-DWITH_PROTOBUF=OFF\
+	..
+
+# Build OpenCV
+# (note we can't use a parallel build here because Docker seems to have some kind of
+#  memory leak bug when doing parallel builds. So unfortunately this will be slow)
+RUN make
+
+# Install OpenCV
+RUN make install
+
+WORKDIR "/"
+
+################### CATCH2 ###################
+WORKDIR "/usr/local/share"
+
+# Download Catch2
+RUN git clone https://github.com/catchorg/catch2
+
+# Configure Catch2
+WORKDIR "/usr/local/share/catch2"
+RUN mkdir build
+WORKDIR "/usr/local/share/catch2/build"
+RUN cmake ..
+
+# Build Catch2
+RUN make
+
+# Install Catch2
+RUN make install
+
+WORKDIR "/"
+
+################### LIDAR ###################
+
+WORKDIR "/usr/local/share"
+
+# Download the URG Lidar library
+RUN git clone https://github.com/andrewbriand/urg_library-1.2.5.git
+WORKDIR "/usr/local/share/urg_library-1.2.5"
+
+# Build URG library
+RUN make
+
+# Install URG library
+RUN make install
+
+WORKDIR "/"
+
+################### ROS2 ###################
+
+# Update locale
+RUN apt-get install -y locales
+RUN locale-gen en_US en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+# Add ROS GPG keys
+RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+RUN sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
+
+# Install ROS
+RUN apt-get update && apt-get install -y ros-foxy-ros-base


### PR DESCRIPTION
This pull request fixes the issue of two SFML windows not being supported on some OSs, causing the simulator and plan visualization not being able to run. The simulator now publishes information for visualization to a ROS topic, and the new PlanViz executable reads information from the topic and displays it. The simulator and plan visualization are now different executables (RoverSim and PlanViz), so a simulator window can be run without visualization and vice versa.

I have also updated the Docker CI to include ROS2. It is now based on Ubuntu 20.04, as support for the ROS2 version that targets Ubuntu 18.04 is ending in May. I have also added a reference version of the Dockerfile used to create the CI image so it is easier to access if it needs to be updated in the future. It is based on the Dockerfile from the previous version of the CI, which can be found at [evan3334/PY2020-test-deps](https://www.github.com/evan3334/PY2020-test-deps). Right now, the reference version is located at `tests-docker-action/rover-test-deps-ros-Dockerfile`; please let me know if it should be stored somewhere else.

A few important things to note:
- The simulator and plan visualization are now different executables (RoverSim and PlanViz)
- As such, the simulator and plan visualization must be run from different terminals if you want to run both simultaneously
- Trying to visualize plans of multiple simulator windows at once will result in unexpected visualization behavior
- However, using multiple plan visualization windows with one simulator window will work as expected
- You can use the same plan visualization window for multiple non-overlapping simulator runs
- The current implementation requires ROS2