### PR TITLE
Implement setCmdVel for the actual rover

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,9 @@ add_library(simulator_world_interface SHARED
 add_library(stub_world_interface SHARED
   simulator/noop_world.cpp
   )
+add_library(real_world_interface SHARED
+  Networking/real_world_interface.cpp
+  )
 
 add_library(real_can_interface SHARED
   Networking/CANUtils.cpp
@@ -78,7 +81,7 @@ add_executable(Rover rover_main.cpp)
 target_link_libraries(Rover ${rover_libs}
   real_base_station
   real_can_interface
-  stub_world_interface # only for now, until we figure out the real sensor interfaces
+  real_world_interface
   )
 
 add_executable(RoverNoCAN rover_main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,6 @@ add_executable(tests
   Networking/tests.cpp
   Networking/TestPackets.cpp
   Networking/NetworkingStubs.cpp
-  Networking/real_world_interface.cpp
   # Autonomy tests
   mapping/ValidatorTest.cpp
   ../tests/kinematics/DiffDriveKinematicsTest.cpp
@@ -125,6 +124,7 @@ target_link_libraries(tests
   ${rover_libs}
   lidar_slam
   stub_can_interface
+  real_world_interface
   )
 
 add_library(lidar_base

--- a/src/Networking/CANUtils.cpp
+++ b/src/Networking/CANUtils.cpp
@@ -94,7 +94,7 @@ int recvCANPacket(CANPacket *packet)
   }
   else
   {
-    std::cout << "Got CAN packet" << std::endl;
+    //std::cout << "Got CAN packet" << std::endl;
     packet->id = can_frame_.can_id;
     packet->dlc = can_frame_.can_dlc;
     for(int i = 0; i < can_frame_.can_dlc; i++)

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -16,10 +16,6 @@ int main() {
   std::string str;
   CANPacket p;
   uint8_t motor_group = 0x04;
-  if (TEST_PWM) {
-    AssembleModeSetPacket(&p, motor_group, (uint8_t) 0x0, (uint8_t) 0x0);
-    sendCANPacket(p);
-  }
   while(1) {
     if (TEST_MODE_SET) {
       std::cout << "Enter motor serial > ";
@@ -39,6 +35,8 @@ int main() {
       std::cout << "Enter PWM > ";
       std::getline(std::cin, str);
       int pwm = std::stoi(str);
+      AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x0);
+      sendCANPacket(p);
       AssemblePWMDirSetPacket(&p, motor_group, (uint8_t) serial, (int16_t) pwm);
       sendCANPacket(p);
     }

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -111,6 +111,7 @@ bool ParseDrivePacket(json &message) {
   {
     return sendError("Drive targets not within bounds +/- 1.0");
   }
-  // TODO do we need to scale or invert these?
-  return setCmdVel(lr, fb);
+  double MAX_X_VEL = 0.25; // m/s
+  double MAX_TH_VEL = 0.5; // rad/s
+  return setCmdVel(lr * MAX_TH_VEL, fb * MAX_X_VEL);
 }

--- a/src/Networking/ParseCAN.cpp
+++ b/src/Networking/ParseCAN.cpp
@@ -70,8 +70,8 @@ extern const std::vector<std::string> telem_types = {
 const std::string getDeviceTelemetryName(CANPacket &p) {
     uint8_t device_group = GetSenderDeviceGroupCode(&p);
     uint8_t device_serial = GetSenderDeviceSerialNumber(&p);
-    std::cout << "device_group " << (int) device_group << " device_serial " <<
-      (int) device_serial << std::endl;
+    //std::cout << "device_group " << (int) device_group << " device_serial " <<
+    //  (int) device_serial << std::endl;
     if (device_group < can_groups.size() &&
         device_serial < can_groups[device_group].size()) {
       return can_groups[device_group][device_serial];
@@ -85,8 +85,8 @@ void ParseCANPacket(CANPacket p)
     if (PacketIsOfID(&p, ID_TELEMETRY_REPORT)) {
         const std::string device_name = getDeviceTelemetryName(p);
         const std::string telem_type = telem_types[DecodeTelemetryType(&p)];
-        std::cout << "Got telemetry packet for device_name and telem_type " <<
-          device_name << " " << telem_type << std::endl;
+        //std::cout << "Got telemetry packet for device_name and telem_type " <<
+        //  device_name << " " << telem_type << std::endl;
         // TODO is this data sometimes unsigned?
         Globals::status_data[device_name][telem_type] = DecodeTelemetryDataSigned(&p);
     }

--- a/src/Networking/real_world_interface.cpp
+++ b/src/Networking/real_world_interface.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../simulator/world_interface.h"
 #include "../simulator/utils.h"
 #include "json.hpp"
@@ -8,20 +9,50 @@ void world_interface_init() {
   return;
 }
 
+const double WHEEL_BASE = 0.8; // eyeballed
+const double WHEEL_RADIUS = 0.2; // eyeballed
+const double PWM_FOR_1RAD_PER_SEC = 10000; // eyeballed
+/*
+dx = (right + left) / 2
+dtheta = (right - left) / (distance bw wheels)
+
+therefore:
+
+2*dx + (distance bw wheels) * dtheta = 2*right
+2*dx - (distance bw wheels) * dtheta = 2*left
+
+now "right" gives the ground velocity of the wheel, so
+right_angular_vel = right / wheel_radius
+
+right_pwm = right_angular_vel * PWM_FOR_1RAD_PER_SEC
+
+*/
+
 bool setCmdVel(double dtheta, double dx)
 {
-  // TODO do we need to scale or invert these values?
   double lr = dtheta;
   double fb = dx;
   // TODO I'm curious how intuitive it would be to use remote control with wheel velocities rather
   // than kinematic velocities. That would actually allow the rover to go faster, I think.
   // Another alternative: add a boolean "wheel_velocities" indicating which mode to use
   // (if true, the other keys should just be "right" and "left").
-  double right = (fb + lr)/2;
-  double left =  (fb - lr)/2;
-  int max_pwm = 1000; // TODO figure out what is the maximum value the hardware supports
-  int right_pwm = (int) max_pwm * right;
-  int left_pwm = (int) max_pwm * left;
+  double right_ground_vel = dx + WHEEL_BASE/2*dtheta;
+  double left_ground_vel = dx - WHEEL_BASE/2*dtheta;
+  double right_angular_vel = right_ground_vel / WHEEL_RADIUS;
+  double left_angular_vel = left_ground_vel / WHEEL_RADIUS;
+  int right_pwm = (int) (right_angular_vel * PWM_FOR_1RAD_PER_SEC);
+  int left_pwm = (int) (left_angular_vel * PWM_FOR_1RAD_PER_SEC);
+  // This is a bit on the conservative side, but we heard an ominous popping sound at 20000.
+  int max_pwm = 15000; 
+  if (abs(right_pwm) > max_pwm) {
+    std::cout << "WARNING: requested too-large right PWM " << right_pwm << std::endl;
+    right_pwm = max_pwm*(right_pwm < 0 ? -1 : 1);
+  }
+  if (abs(left_pwm) > max_pwm) {
+    std::cout << "WARNING: requested too-large left PWM " << left_pwm << std::endl;
+    left_pwm = max_pwm*(left_pwm < 0 ? -1 : 1);
+  }
+
   json packet = {};
   packet["type"] = "motor";
   packet["mode"] = "PWM";

--- a/src/Networking/real_world_interface.cpp
+++ b/src/Networking/real_world_interface.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "../simulator/world_interface.h"
 #include "../simulator/utils.h"
+#include "../Globals.h"
 #include "json.hpp"
 #include "motor_interface.h"
 #include "CANUtils.h"
@@ -22,6 +23,8 @@ const double PWM_FOR_1RAD_PER_SEC = 10000; // Eyeballed
 
 bool setCmdVel(double dtheta, double dx)
 {
+  if (Globals::E_STOP && (dtheta != 0 || dx != 0)) return false;
+
   /* This is the inverse of the formula:
    *    dx = (right_ground_vel + left_ground_vel) / 2
    *    dtheta = (right_ground_vel - left_ground_vel) / WHEEL_BASE

--- a/src/Networking/real_world_interface.cpp
+++ b/src/Networking/real_world_interface.cpp
@@ -16,33 +16,16 @@ void world_interface_init() {
   return;
 }
 
-const double WHEEL_BASE = 1.0; // eyeballed
-const double WHEEL_RADIUS = 0.15; // eyeballed
-const double PWM_FOR_1RAD_PER_SEC = 10000; // eyeballed
-/*
-dx = (right + left) / 2
-dtheta = (right - left) / (distance bw wheels)
-
-therefore:
-
-2*dx + (distance bw wheels) * dtheta = 2*right
-2*dx - (distance bw wheels) * dtheta = 2*left
-
-now "right" gives the ground velocity of the wheel, so
-right_angular_vel = right / wheel_radius
-
-right_pwm = right_angular_vel * PWM_FOR_1RAD_PER_SEC
-
-*/
+const double WHEEL_BASE = 1.0; // Distance between left and right wheels. Eyeballed
+const double WHEEL_RADIUS = 0.15; // Eyeballed
+const double PWM_FOR_1RAD_PER_SEC = 10000; // Eyeballed
 
 bool setCmdVel(double dtheta, double dx)
 {
-  double lr = dtheta;
-  double fb = dx;
-  // TODO I'm curious how intuitive it would be to use remote control with wheel velocities rather
-  // than kinematic velocities. That would actually allow the rover to go faster, I think.
-  // Another alternative: add a boolean "wheel_velocities" indicating which mode to use
-  // (if true, the other keys should just be "right" and "left").
+  /* This is the inverse of the formula:
+   *    dx = (right_ground_vel + left_ground_vel) / 2
+   *    dtheta = (right_ground_vel - left_ground_vel) / WHEEL_BASE
+   */
   double right_ground_vel = dx + WHEEL_BASE/2*dtheta;
   double left_ground_vel = dx - WHEEL_BASE/2*dtheta;
   double right_angular_vel = right_ground_vel / WHEEL_RADIUS;
@@ -50,7 +33,7 @@ bool setCmdVel(double dtheta, double dx)
   int16_t right_pwm = (int16_t) (right_angular_vel * PWM_FOR_1RAD_PER_SEC);
   int16_t left_pwm = (int16_t) (left_angular_vel * PWM_FOR_1RAD_PER_SEC);
   // This is a bit on the conservative side, but we heard an ominous popping sound at 20000.
-  int16_t max_pwm = 15000; 
+  int16_t max_pwm = 15000;
   if (abs(right_pwm) > max_pwm) {
     std::cout << "WARNING: requested too-large right PWM " << right_pwm << std::endl;
     right_pwm = max_pwm*(right_pwm < 0 ? -1 : 1);

--- a/src/Networking/real_world_interface.cpp
+++ b/src/Networking/real_world_interface.cpp
@@ -16,9 +16,9 @@ void world_interface_init() {
   return;
 }
 
-const double WHEEL_BASE = 0.8; // eyeballed
-const double WHEEL_RADIUS = 0.2; // eyeballed
-const double PWM_FOR_1RAD_PER_SEC = 8000; // eyeballed
+const double WHEEL_BASE = 1.0; // eyeballed
+const double WHEEL_RADIUS = 0.15; // eyeballed
+const double PWM_FOR_1RAD_PER_SEC = 10000; // eyeballed
 /*
 dx = (right + left) / 2
 dtheta = (right - left) / (distance bw wheels)

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -66,7 +66,7 @@ int rover_loop(int argc, char **argv)
         if (recvBaseStationPacket(buffer) != 0) {
             ParseBaseStationPacket(buffer);
         }
-        autonomous.autonomyIter();
+        //autonomous.autonomyIter();
 
         gettimeofday(&tp0, NULL);
         long elapsedUsecs = (tp0.tv_sec - tp_start.tv_sec) * 1000 * 1000 + (tp0.tv_usec - tp_start.tv_usec);

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -27,14 +27,10 @@ void InitializeRover()
     // Set all wheel motors to mode PWM
     uint8_t motor_group = 0x4;
     uint8_t mode_PWM = 0x0;
-    uint16_t test_PWM = -5000;
     for (uint8_t serial = 0x8; serial < 0xC; serial ++ ) {
       AssembleModeSetPacket(&p, motor_group, serial, mode_PWM);
       sendCANPacket(p);
-      //AssemblePWMDirSetPacket(&p, motor_group, serial, test_PWM);
-      //sendCANPacket(p);
     }
-    setCmdVel(0.0, 0.25);
 }
 
 void closeSim(int signum)

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -43,7 +43,7 @@ const double CONTROL_HZ = 10.0;
 
 int rover_loop(int argc, char **argv)
 {
-    //world_interface_init();
+    world_interface_init();
     rclcpp::init(0, nullptr);
     // Ctrl+C doesn't stop the simulation without this line
     signal(SIGINT, closeSim);

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -66,7 +66,7 @@ int rover_loop(int argc, char **argv)
         if (recvBaseStationPacket(buffer) != 0) {
             ParseBaseStationPacket(buffer);
         }
-        //autonomous.autonomyIter();
+        autonomous.autonomyIter();
 
         gettimeofday(&tp0, NULL);
         long elapsedUsecs = (tp0.tv_sec - tp_start.tv_sec) * 1000 * 1000 + (tp0.tv_usec - tp_start.tv_usec);


### PR DESCRIPTION
The very conservative MAX_X_VEL and MAX_TH_VEL values in ParseBaseStation.cpp will be annoying when working with the simulator, but I think for now it's best (safest) to set these to small values.

The FakeCANBoard changes are unrelated, but still worth merging as this ended up being the most useful way to test PWM packets.

Video using the changes from this PR: https://photos.app.goo.gl/8u72LgDHG7dh9FT38