### PR TITLE
Added missing include

### DIFF
--- a/src/worldmap/GlobalMap.cpp
+++ b/src/worldmap/GlobalMap.cpp
@@ -1,5 +1,7 @@
 #include "GlobalMap.h"
 
+#include <Eigen/LU>
+
 /*
  * Since the map is transformed to fit the sample, and there might be a lot of points in the
  * global map, we don't transform the entire map with each sample. Instead, we only transform


### PR DESCRIPTION
GlobalMap uses the matrix inverse but doesn't include `<Eigen/LU>`, so this is a quick fix to that.