### PR TITLE
Update OpenCV install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ access.
 
 ## Install OpenCV
 OpenCV is a computer vision library that's used for the AR tag detection code
-and as such is needed to compile the project.
-
-The setup process takes some time and will use a lot of CPU, but it's fairly
-straightforward and should only need to be done once.
-
-We need an extra module (ARUco) for OpenCV for the AR tag detection code which
-is not bundled with OpenCV, so you will have to install that module before
-building OpenCV. The below instructions will cover this.
+and as such is needed to compile the project. We will also need the OpenCV
+contrib modules for the AR tag detection code. Either OpenCV 3 or OpenCV 4
+should work, but we are developing and testing against OpenCV 4 so you should
+try to get that version for best results.
 
 ### On GNU/Linux (including Windows Subsystem for Linux)
 
@@ -34,45 +30,14 @@ GNU/Linux distribution natively or in a VM, you can often paste with
 `CTRL+SHIFT+v`. If you are using Windows Subsystem for Linux, these commands
 should be executed in your WSL terminal, and you can paste with right click.
 
-1. `sudo apt update && sudo apt -y dist-upgrade`
-2. `sudo apt install unzip git cmake g++ libgtk2.0-dev pkg-config libavcodec-dev
-   libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev
-   libtiff-dev libdc1394-22-dev`
-   
-Now, to install the extra modules:
+OpenCV and its contrib modules are packaged for Ubuntu GNU/Linux. For other
+distributions, check to see if `libopencv` and `libopencv-contrib` are included
+in your distribution's package catalog. 
 
-3. `git clone https://github.com/opencv/opencv_contrib`
-4. `cd opencv_contrib`
-5. `git checkout 3.4.7`
+To install, simply run the following commands:
 
-We will do the next two steps because the contrib repository comes with many
-extra modules, and we only need the one for ARUco. Copying it into its own
-directory will allow us to only build and include that one module instead of
-having to build all of them.
-
-6. `mkdir selected_modules`
-7. `cp -r modules/aruco selected_modules/`
-
-Return to your original directory.
-
-8. `cd ..`
-
-Now, to install and build OpenCV, with the extra modules:
-
-9. `wget https://github.com/opencv/opencv/archive/3.4.7.zip`
-10. `unzip 3.4.7.zip`
-11. `cd opencv-3.4.7`
-12. `mkdir build`
-13. `cd build`
-14. `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local
-    -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/selected_modules ..` 
-15. `make -j$(nproc)` (The command `nproc` here will return the number of CPU
-   cores on your computer, and will enable `make` to build in parallel, which
-   will make the build process go faster.) This step will take a long
-   time and use nearly 100% CPU for that entire time, so be warned. If you are a
-   VM user, this process can go faster if you allocate more processor cores to
-   your VM.
-16. `sudo make install`
+1. `sudo apt update && sudo apt -y upgrade`
+2. `sudo apt install libopencv-dev libopencv-contrib-dev`
 
 ### On Mac
 There is a Homebrew package available for OpenCV on Mac OS. Open the Terminal
@@ -80,7 +45,7 @@ and run these commands:
 1. `/usr/bin/ruby -e "$(curl -fsSL
    https://raw.githubusercontent.com/Homebrew/install/master/install)"` (If you
    already have Homebrew installed, you can skip this step.)
-2. `brew install opencv@3`
+2. `brew install opencv@4`
 
 ## Install Catch2 (for unit testing)
 These instructions assume you've followed the steps above to set up OpenCV,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,7 @@ list(APPEND sfml_libs
 find_package(Eigen3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
+target_include_directories(lidar_base SYSTEM PUBLIC ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})
 target_link_libraries(Rover ${OpenCV_LIBS} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})

--- a/tests-docker-action/rover-test-deps-ros-Dockerfile
+++ b/tests-docker-action/rover-test-deps-ros-Dockerfile
@@ -21,49 +21,8 @@ RUN apt-get install -y libeigen3-dev
 
 ################### OPENCV ###################
 
-WORKDIR "/usr/local/share"
-# Install dependencies for OpenCV
-RUN apt-get install -y build-essential
-RUN apt-get install -y cmake git libgtk2.0-dev pkg-config libavcodec-dev \
-	libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev \
-	libpng-dev libtiff-dev libdc1394-22-dev
-
-# Download OpenCV tarball
-RUN wget -O /tmp/3.4.7.zip https://github.com/opencv/opencv/archive/3.4.7.zip
-
-# Unpack OpenCV tarball
-RUN unzip /tmp/3.4.7.zip
-
-# Download OpenCV contrib modules
-RUN git clone https://github.com/opencv/opencv_contrib
-WORKDIR "/usr/local/share/opencv_contrib"
-RUN git checkout 3.4.7
-
-# Enable only specific contrib modules
-RUN mkdir enabled_modules
-RUN cp -r modules/aruco enabled_modules/
-WORKDIR "/usr/local/share"
-
-# Configure OpenCV build
-WORKDIR "/usr/local/share/opencv-3.4.7"
-RUN mkdir build
-WORKDIR "/usr/local/share/opencv-3.4.7/build"
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DENABLE_PRECOMPILED_HEADERS=OFF \
-	-DOPENCV_EXTRA_MODULES_PATH=/usr/local/share/opencv_contrib/enabled_modules/ \
-	-DBUILD_OPENEXR=OFF -DWITH_OPENEXR=OFF -DBUILD_PROTOBUF=OFF \
-	-DWITH_PROTOBUF=OFF\
-	..
-
-# Build OpenCV
-# (note we can't use a parallel build here because Docker seems to have some kind of
-#  memory leak bug when doing parallel builds. So unfortunately this will be slow)
-RUN make
-
 # Install OpenCV
-RUN make install
-
-WORKDIR "/"
+RUN apt-get install -y libopencv-dev libopencv-contrib-dev
 
 ################### CATCH2 ###################
 WORKDIR "/usr/local/share"

--- a/tests-docker-action/rover-test-deps-ros-Dockerfile
+++ b/tests-docker-action/rover-test-deps-ros-Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 
 # Install system dependencies
-RUN apt-get install -y wget unzip curl gnupg2 lsb-release
+RUN apt-get install -y wget unzip curl gnupg2 lsb-release git cmake g++ make
 
 ################### SFML ###################
 
@@ -25,15 +25,19 @@ RUN apt-get install -y libeigen3-dev
 RUN apt-get install -y libopencv-dev libopencv-contrib-dev
 
 ################### CATCH2 ###################
-WORKDIR "/usr/local/share"
+WORKDIR "/tmp"
 
 # Download Catch2
 RUN git clone https://github.com/catchorg/catch2
 
 # Configure Catch2
-WORKDIR "/usr/local/share/catch2"
+WORKDIR "/tmp/catch2"
+# Check out the correct release tag
+RUN git checkout v2.13.4
+# Make build directory
 RUN mkdir build
-WORKDIR "/usr/local/share/catch2/build"
+WORKDIR "/tmp/catch2/build"
+# Run CMake config
 RUN cmake ..
 
 # Build Catch2
@@ -42,21 +46,29 @@ RUN make
 # Install Catch2
 RUN make install
 
+# Clean up sources to save storage space
+WORKDIR "/tmp"
+RUN rm -rf catch2
+
 WORKDIR "/"
 
 ################### LIDAR ###################
 
-WORKDIR "/usr/local/share"
+WORKDIR "/tmp/"
 
 # Download the URG Lidar library
 RUN git clone https://github.com/andrewbriand/urg_library-1.2.5.git
-WORKDIR "/usr/local/share/urg_library-1.2.5"
+WORKDIR "/tmp/urg_library-1.2.5"
 
 # Build URG library
 RUN make
 
 # Install URG library
 RUN make install
+
+# Clean up sources to save storage space
+WORKDIR "/tmp"
+RUN rm -rf urg_library-1.2.5
 
 WORKDIR "/"
 


### PR DESCRIPTION
Our install instructions are currently to do a custom source build of OpenCV 3 with certain contrib modules mixed in; however, this is pretty unhygienic and wasteful to do on every new setup, and we probably ought to be using the version that comes with the system package manager. On most current Ubuntu installations OpenCV 4 is packaged; we've tested and it seems to be compatible (at least, the parts we used in our code) out of the box with OpenCV 3, so no code changes should be required to move to OpenCV 4 installed from APT. 

All this pull request really does is update the install instructions and change the Dockerfile that defines the image the CI runs tests on to also use those install instructions instead of building from source.