### PR TITLE
Add DEFAULT_FASTRTPS_PROFILES.xml

### DIFF
--- a/DEFAULT_FASTRTPS_PROFILES.xml
+++ b/DEFAULT_FASTRTPS_PROFILES.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<profiles> 
+    <participant profile_name="participant_profile" is_default_profile="true"> 
+        <rtps> 
+            <builtin> 
+                <metatrafficUnicastLocatorList> 
+                    <locator/> 
+                </metatrafficUnicastLocatorList> 
+                <initialPeersList> 
+                    <locator> 
+                        <udpv4>
+                          <address>10.19.75.206</address> 
+                        </udpv4>
+                    </locator> 
+                    <locator> 
+                        <udpv4>
+                          <address>40.40.40.40</address> 
+                        </udpv4>
+                    </locator> 
+                    <locator> 
+                        <udpv4>
+                          <address>172.25.116.157</address> 
+                        </udpv4>
+                    </locator> 
+                </initialPeersList> 
+            </builtin> 
+        </rtps> 
+    </participant> 
+</profiles>
+


### PR DESCRIPTION
ROS2, unlike ROS, uses some fancy middleware protocol for discovering
other nodes on the network. For some reason, it wasn't working when
connecting my laptop to the rover. So instead, we use this XML file to
explicitly tell ROS nodes which IP addresses to connect to.

Usage: This XML file needs to be in the same directory as the executable
and/or the current working directory of your shell. So on the rover, put
it in the `build` directory and make sure your shell is "in" that directory
before trying to run any commands like `./Rover`.

40.40.40.40 is a fake IP address to test whether the XML file is
actually being loaded by ROS2. You can check this with:

sudo tcpdump -v | grep 40.40.40.40

The other two IP addresses are my laptop and the rover (in the ME annex
building's network).