### PR TITLE
Update calibration program to latest version, from OpenCV 4

### DIFF
--- a/src/ar/calibration.cpp
+++ b/src/ar/calibration.cpp
@@ -1,12 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////////////
 //
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
+// Program to calibrate a camera. Taken from OpenCV sample code, original
+// license agreement is below:
+// 
 //                           License Agreement
 //                For Open Source Computer Vision Library
 //
@@ -54,6 +50,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <iostream>
 
 using namespace cv;
 using namespace std;
@@ -90,10 +87,10 @@ const char* liveCaptureHelp =
         "  'g' - start capturing images\n"
         "  'u' - switch undistortion on/off\n";
 
-static void help(char** argv)
+static void help()
 {
     printf( "This is a camera calibration sample.\n"
-        "Usage: %s\n"
+        "Usage: calibration\n"
         "     -w=<board_width>         # the number of inner corners per one of board dimension\n"
         "     -h=<board_height>        # the number of inner corners per another board dimension\n"
         "     [-pt=<pattern>]          # the type of pattern: chessboard or circles' grid\n"
@@ -106,6 +103,7 @@ static void help(char** argv)
         "     [-o=<out_camera_params>] # the output filename for intrinsic [and extrinsic] parameters\n"
         "     [-op]                    # write detected feature points\n"
         "     [-oe]                    # write extrinsic parameters\n"
+        "     [-oo]                    # write refined 3D object points\n"
         "     [-zt]                    # assume zero tangential distortion\n"
         "     [-a=<aspectRatio>]      # fix aspect ratio (fx/fy)\n"
         "     [-p]                     # fix the principal point at the center\n"
@@ -113,12 +111,17 @@ static void help(char** argv)
         "     [-V]                     # use a video file, and not an image list, uses\n"
         "                              # [input_data] string for the video file name\n"
         "     [-su]                    # show undistorted images after calibration\n"
+        "     [-ws=<number_of_pixel>]  # Half of search window for cornerSubPix (11 by default)\n"
+        "     [-dt=<distance>]         # actual distance between top-left and top-right corners of\n"
+        "                              # the calibration grid. If this parameter is specified, a more\n"
+        "                              # accurate calibration method will be used which may be better\n"
+        "                              # with inaccurate, roughly planar target.\n"
         "     [input_data]             # input data, one of the following:\n"
         "                              #  - text file with a list of the images of the board\n"
         "                              #    the text file can be generated with imagelist_creator\n"
         "                              #  - name of video file with a video of the board\n"
         "                              # if input_data not specified, a live view from the camera is used\n"
-        "\n", argv[0] );
+        "\n" );
     printf("\n%s",usage);
     printf( "\n%s", liveCaptureHelp );
 }
@@ -181,9 +184,11 @@ static void calcChessboardCorners(Size boardSize, float squareSize, vector<Point
 static bool runCalibration( vector<vector<Point2f> > imagePoints,
                     Size imageSize, Size boardSize, Pattern patternType,
                     float squareSize, float aspectRatio,
+                    float grid_width, bool release_object,
                     int flags, Mat& cameraMatrix, Mat& distCoeffs,
                     vector<Mat>& rvecs, vector<Mat>& tvecs,
                     vector<float>& reprojErrs,
+                    vector<Point3f>& newObjPoints,
                     double& totalAvgErr)
 {
     cameraMatrix = Mat::eye(3, 3, CV_64F);
@@ -194,16 +199,32 @@ static bool runCalibration( vector<vector<Point2f> > imagePoints,
 
     vector<vector<Point3f> > objectPoints(1);
     calcChessboardCorners(boardSize, squareSize, objectPoints[0], patternType);
+    objectPoints[0][boardSize.width - 1].x = objectPoints[0][0].x + grid_width;
+    newObjPoints = objectPoints[0];
 
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
 
-    double rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix,
-                    distCoeffs, rvecs, tvecs, flags|CALIB_FIX_K4|CALIB_FIX_K5);
-                    ///*|CALIB_FIX_K3*/|CALIB_FIX_K4|CALIB_FIX_K5);
+    double rms;
+    int iFixedPoint = -1;
+    if (release_object)
+        iFixedPoint = boardSize.width - 1;
+    rms = calibrateCameraRO(objectPoints, imagePoints, imageSize, iFixedPoint,
+                            cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                            flags | CALIB_FIX_K3 | CALIB_USE_LU);
     printf("RMS error reported by calibrateCamera: %g\n", rms);
 
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);
 
+    if (release_object) {
+        cout << "New board corners: " << endl;
+        cout << newObjPoints[0] << endl;
+        cout << newObjPoints[boardSize.width - 1] << endl;
+        cout << newObjPoints[boardSize.width * (boardSize.height - 1)] << endl;
+        cout << newObjPoints.back() << endl;
+    }
+
+    objectPoints.clear();
+    objectPoints.resize(imagePoints.size(), newObjPoints);
     totalAvgErr = computeReprojectionErrors(objectPoints, imagePoints,
                 rvecs, tvecs, cameraMatrix, distCoeffs, reprojErrs);
 
@@ -218,6 +239,7 @@ static void saveCameraParams( const string& filename,
                        const vector<Mat>& rvecs, const vector<Mat>& tvecs,
                        const vector<float>& reprojErrs,
                        const vector<vector<Point2f> >& imagePoints,
+                       const vector<Point3f>& newObjPoints,
                        double totalAvgErr )
 {
     FileStorage fs( filename, FileStorage::WRITE );
@@ -290,6 +312,11 @@ static void saveCameraParams( const string& filename,
         }
         fs << "image_points" << imagePtMat;
     }
+
+    if( !newObjPoints.empty() )
+    {
+        fs << "grid_points" << newObjPoints;
+    }
 }
 
 static bool readStringList( const string& filename, vector<string>& l )
@@ -330,17 +357,19 @@ static bool readStringList( const string& filename, vector<string>& l )
 static bool runAndSave(const string& outputFilename,
                 const vector<vector<Point2f> >& imagePoints,
                 Size imageSize, Size boardSize, Pattern patternType, float squareSize,
+                float grid_width, bool release_object,
                 float aspectRatio, int flags, Mat& cameraMatrix,
-                Mat& distCoeffs, bool writeExtrinsics, bool writePoints )
+                Mat& distCoeffs, bool writeExtrinsics, bool writePoints, bool writeGrid )
 {
     vector<Mat> rvecs, tvecs;
     vector<float> reprojErrs;
     double totalAvgErr = 0;
+    vector<Point3f> newObjPoints;
 
     bool ok = runCalibration(imagePoints, imageSize, boardSize, patternType, squareSize,
-                   aspectRatio, flags, cameraMatrix, distCoeffs,
-                   rvecs, tvecs, reprojErrs, totalAvgErr);
-    printf("%s. avg reprojection error = %.2f\n",
+                   aspectRatio, grid_width, release_object, flags, cameraMatrix, distCoeffs,
+                   rvecs, tvecs, reprojErrs, newObjPoints, totalAvgErr);
+    printf("%s. avg reprojection error = %.7f\n",
            ok ? "Calibration succeeded" : "Calibration failed",
            totalAvgErr);
 
@@ -352,6 +381,7 @@ static bool runAndSave(const string& outputFilename,
                          writeExtrinsics ? tvecs : vector<Mat>(),
                          writeExtrinsics ? reprojErrs : vector<float>(),
                          writePoints ? imagePoints : vector<vector<Point2f> >(),
+                         writeGrid ? newObjPoints : vector<Point3f>(),
                          totalAvgErr );
     return ok;
 }
@@ -360,7 +390,7 @@ static bool runAndSave(const string& outputFilename,
 int main( int argc, char** argv )
 {
     Size boardSize, imageSize;
-    float squareSize, aspectRatio;
+    float squareSize, aspectRatio = 1;
     Mat cameraMatrix, distCoeffs;
     string outputFilename;
     string inputFilename = "";
@@ -383,11 +413,12 @@ int main( int argc, char** argv )
 
     cv::CommandLineParser parser(argc, argv,
         "{help ||}{w||}{h||}{pt|chessboard|}{n|10|}{d|1000|}{s|1|}{o|out_camera_data.yml|}"
-        "{op||}{oe||}{zt||}{a|1|}{p||}{v||}{V||}{su||}"
+        "{op||}{oe||}{zt||}{a||}{p||}{v||}{V||}{su||}"
+        "{oo||}{ws|11|}{dt||}"
         "{@input_data|0|}");
     if (parser.has("help"))
     {
-        help(argv);
+        help();
         return 0;
     }
     boardSize.width = parser.get<int>( "w" );
@@ -406,12 +437,14 @@ int main( int argc, char** argv )
     }
     squareSize = parser.get<float>("s");
     nframes = parser.get<int>("n");
-    aspectRatio = parser.get<float>("a");
     delay = parser.get<int>("d");
     writePoints = parser.has("op");
     writeExtrinsics = parser.has("oe");
-    if (parser.has("a"))
+    bool writeGrid = parser.has("oo");
+    if (parser.has("a")) {
         flags |= CALIB_FIX_ASPECT_RATIO;
+        aspectRatio = parser.get<float>("a");
+    }
     if ( parser.has("zt") )
         flags |= CALIB_ZERO_TANGENT_DIST;
     if ( parser.has("p") )
@@ -425,9 +458,16 @@ int main( int argc, char** argv )
         cameraId = parser.get<int>("@input_data");
     else
         inputFilename = parser.get<string>("@input_data");
+    int winSize = parser.get<int>("ws");
+    float grid_width = squareSize * (boardSize.width - 1);
+    bool release_object = false;
+    if (parser.has("dt")) {
+        grid_width = parser.get<float>("dt");
+        release_object = true;
+    }
     if (!parser.check())
     {
-        help(argv);
+        help();
         parser.printErrors();
         return -1;
     }
@@ -483,9 +523,9 @@ int main( int argc, char** argv )
         {
             if( imagePoints.size() > 0 )
                 runAndSave(outputFilename, imagePoints, imageSize,
-                           boardSize, pattern, squareSize, aspectRatio,
+                           boardSize, pattern, squareSize, grid_width, release_object, aspectRatio,
                            flags, cameraMatrix, distCoeffs,
-                           writeExtrinsics, writePoints);
+                           writeExtrinsics, writePoints, writeGrid);
             break;
         }
 
@@ -515,8 +555,8 @@ int main( int argc, char** argv )
         }
 
        // improve the found corners' coordinate accuracy
-        if( pattern == CHESSBOARD && found) cornerSubPix( viewGray, pointbuf, Size(11,11),
-            Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.1 ));
+        if( pattern == CHESSBOARD && found) cornerSubPix( viewGray, pointbuf, Size(winSize,winSize),
+            Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.0001 ));
 
         if( mode == CAPTURING && found &&
            (!capture.isOpened() || clock() - prevTimestamp > delay*1e-3*CLOCKS_PER_SEC) )
@@ -573,9 +613,9 @@ int main( int argc, char** argv )
         if( mode == CAPTURING && imagePoints.size() >= (unsigned)nframes )
         {
             if( runAndSave(outputFilename, imagePoints, imageSize,
-                       boardSize, pattern, squareSize, aspectRatio,
+                       boardSize, pattern, squareSize, grid_width, release_object, aspectRatio,
                        flags, cameraMatrix, distCoeffs,
-                       writeExtrinsics, writePoints))
+                       writeExtrinsics, writePoints, writeGrid))
                 mode = CALIBRATED;
             else
                 mode = DETECTION;


### PR DESCRIPTION
This pull request updates the calibration sample program to the latest version that is available in OpenCV 4. Notable changes include the use of the "releasing-object" method of camera calibration, which is more accurate for less precise calibration targets (like the printed paper targets we will most likely be using). We probably ought to use this when we calibrate the cameras on the rover. I'll update the documentation on camera calibration to include info on this.

Note that this new program uses functions that have been introduced in OpenCV 4, so as such OpenCV 4 will be *required* to build it. I don't actually think it will affect the entire project, you have to explicitly specify that you want to build the calibration program so people using OpenCV 3 should still be fine for the time being - however, we probably want to have everyone update at some point.