### PR TITLE
Add code to Rover.cpp to initialize encoders & add PID tuning script

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,12 +79,16 @@ add_library(stub_can_interface SHARED
 list(APPEND rover_libs
   rover_common hindsight_can simulator_base simulator_nav)
 
+list(APPEND sfml_libs
+  sfml-graphics sfml-window sfml-system pthread)
+
 add_executable(Rover rover_main.cpp)
 target_link_libraries(Rover ${rover_libs}
   real_base_station
   real_can_interface
   real_world_interface
   )
+target_link_libraries(Rover ${OpenCV_LIBS} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES} ${sfml_libs})
 
 add_executable(RoverNoCAN rover_main.cpp)
 target_link_libraries(RoverNoCAN ${rover_libs}
@@ -92,6 +96,7 @@ target_link_libraries(RoverNoCAN ${rover_libs}
   stub_can_interface
   stub_world_interface
   )
+target_link_libraries(RoverNoCAN ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 
 add_executable(RoverSim rover_main.cpp)
 target_link_libraries(RoverSim ${rover_libs}
@@ -99,10 +104,20 @@ target_link_libraries(RoverSim ${rover_libs}
   stub_can_interface
   simulator_world_interface
   )
+target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
+
+add_executable(TunePID TunePID.cpp)
+target_link_libraries(TunePID ${rover_libs}
+  real_base_station
+  real_can_interface
+  real_world_interface
+  )
+target_link_libraries(TunePID ${OpenCV_LIBS} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES} ${sfml_libs})
 
 add_executable(PlanViz
   PlanViz.cpp)
 target_link_libraries(PlanViz simulator_base)
+target_link_libraries(PlanViz ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 
 add_executable(tests
   Tests.cpp
@@ -135,11 +150,18 @@ target_link_libraries(tests
   stub_can_interface
   real_world_interface
   )
+include(CTest)
+include(Catch)
+target_link_libraries(tests ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
+target_link_libraries(tests Catch2::Catch2)
+target_link_libraries(tests ${OpenCV_LIBS})
+catch_discover_tests(tests)
 
 add_library(lidar_base
     lidar/LidarVis.cpp
     lidar/PointCloudProcessing.cpp
     lidar/URGLidar.cpp)
+target_include_directories(lidar_base SYSTEM PUBLIC ${OpenCV_INCLUDE_DIRS})
 
 add_library(lidar_slam
         mapping/EKFSlam/EKFSlam.cpp
@@ -150,43 +172,27 @@ add_library(lidar_slam
 add_executable(lidar_vis
     lidar/MainVis.cpp)
 target_link_libraries(lidar_vis lidar_base)
+target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
 
 add_executable(lidarOnlyTest
         mapping/EKFSlam/lidarOnlyTest.cpp
         )
 target_link_libraries(lidarOnlyTest lidar_base lidar_slam)
+target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})
 
 add_executable(simulator_navigation_demo
   simulator/navigation.cpp
   )
 target_link_libraries(simulator_navigation_demo
   simulator_base simulator_nav simulator_world_interface)
+target_link_libraries(simulator_navigation_demo ${sfml_libs})
 
 add_subdirectory(ar)
 
-list(APPEND sfml_libs
-  sfml-graphics sfml-window sfml-system pthread)
 
 # My IDE kept yelling at me until I added these lines. I'm still able to build on the VM so I think it doesn't break anything
 find_package(Eigen3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
-
-target_include_directories(lidar_base SYSTEM PUBLIC ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(lidar_vis liburg_c.a ${OpenCV_LIBS})
-target_link_libraries(lidarOnlyTest liburg_c.a ${OpenCV_LIBS})
-target_link_libraries(Rover ${OpenCV_LIBS} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
-target_link_libraries(RoverNoCAN ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
-target_link_libraries(Rover ${sfml_libs})
-target_link_libraries(RoverSim ${OpenCV_LIBS} ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
-target_link_libraries(simulator_navigation_demo ${sfml_libs})
-target_link_libraries(tests ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
-target_link_libraries(PlanViz ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
-
-include(CTest)
-include(Catch)
-target_link_libraries(tests Catch2::Catch2)
-target_link_libraries(tests ${OpenCV_LIBS})
-catch_discover_tests(tests)
 
 add_executable(Server
   Networking/Server.cpp)

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -32,7 +32,7 @@ void initEncoders()
       sendCANPacket(p);
       usleep(1000); // We're running out of CAN buffer space
       AssembleEncoderPPJRSetPacket(   &p, DEVICE_GROUP_MOTOR_CONTROL, serial,
-          1024); // I have no idea how many pulses actually make one rotation
+          360 * 1000); // I have no idea how many pulses actually make one rotation
       sendCANPacket(p);
       usleep(1000); // We're running out of CAN buffer space
       AssembleTelemetryTimingPacket(  &p, DEVICE_GROUP_MOTOR_CONTROL, serial,

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -71,7 +71,9 @@ void InitializeRover(uint8_t arm_mode)
     }
 
     initEncoders();
-    usleep(1 * 1000 * 1000);
+    // Weird bug on AVR boards. Without this delay, the AVR boards won't move the motors when
+    // we use PWM control later. (This problem does not arise if we do not call initEncoders.)
+    usleep(1 * 1000 * 1000); 
     setArmMode(arm_mode);
 }
 

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -2,6 +2,7 @@
 #include <sys/time.h>
 #include <ctime>
 #include <csignal>
+#include <unistd.h>
 
 #include "CommandLineOptions.h"
 #include "Globals.h"

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -61,7 +61,6 @@ void InitializeRover(uint8_t arm_mode)
 
     // Set all wheel motors to mode PWM
     CANPacket p;
-    uint8_t mode_PWM = 0x0;
     for (uint8_t serial = DEVICE_SERIAL_MOTOR_CHASSIS_FL;
         serial <= DEVICE_SERIAL_MOTOR_CHASSIS_BR;
         serial ++) {
@@ -73,7 +72,7 @@ void InitializeRover(uint8_t arm_mode)
     initEncoders();
     // Weird bug on AVR boards. Without this delay, the AVR boards won't move the motors when
     // we use PWM control later. (This problem does not arise if we do not call initEncoders.)
-    usleep(1 * 1000 * 1000); 
+    usleep(1 * 1000 * 1000);
     setArmMode(arm_mode);
 }
 

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -24,7 +24,7 @@ void initEncoders()
 {
     CANPacket p;
     for (uint8_t serial = DEVICE_SERIAL_MOTOR_BASE;
-        serial < DEVICE_SERIAL_MOTOR_CHASSIS_BR;
+        serial <= DEVICE_SERIAL_MOTOR_HAND;
         serial ++ ) {
       AssembleEncoderInitializePacket(&p, DEVICE_GROUP_MOTOR_CONTROL, serial,
           0, 0, 1); // 1 means to zero the encoder angle measurement
@@ -40,7 +40,7 @@ void setArmMode(uint8_t mode)
     // Set all arm motors to given mode
     CANPacket p;
     for (uint8_t serial = DEVICE_SERIAL_MOTOR_BASE;
-        serial < DEVICE_SERIAL_MOTOR_HAND;
+        serial <= DEVICE_SERIAL_MOTOR_HAND;
         serial ++ ) {
       AssembleModeSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, serial, mode);
       sendCANPacket(p);
@@ -55,7 +55,7 @@ void InitializeRover(uint8_t arm_mode)
     CANPacket p;
     uint8_t mode_PWM = 0x0;
     for (uint8_t serial = DEVICE_SERIAL_MOTOR_CHASSIS_FL;
-        serial < DEVICE_SERIAL_MOTOR_CHASSIS_BR;
+        serial <= DEVICE_SERIAL_MOTOR_CHASSIS_BR;
         serial ++) {
       AssembleModeSetPacket(&p, DEVICE_GROUP_MOTOR_CONTROL, serial, MOTOR_UNIT_MODE_PWM);
       sendCANPacket(p);

--- a/src/Rover.h
+++ b/src/Rover.h
@@ -1,4 +1,7 @@
 
 #pragma once
 
+#include <stdint.h>
+
+void InitializeRover(uint8_t arm_mode);
 int rover_loop(int argc, char** argv);

--- a/src/TunePID.cpp
+++ b/src/TunePID.cpp
@@ -27,6 +27,7 @@ void cleanup(int signum) {
   CANPacket p;
   AssembleGroupBroadcastingEmergencyStopPacket(&p, motor_group_id, ESTOP_ERR_GENERAL);
   sendCANPacket(p);
+  usleep(1000); // Give the packet time to be sent
   exit(0);
 }
 
@@ -36,8 +37,8 @@ int main(int argc, char** argv)
     InitializeRover(MOTOR_UNIT_MODE_PID);
     struct timeval tp0, tp_start;
 
-    // todo add this to our makefile
-    // todo how do we find the PPJR for each motor?
+    // TODO: Before running this script, make sure the PPJR is set correctly for each motor
+    // in Rover.cpp.
 
     signal(SIGINT, cleanup);
 

--- a/src/TunePID.cpp
+++ b/src/TunePID.cpp
@@ -1,0 +1,107 @@
+#include <time.h>
+#include <sys/time.h>
+#include <ctime>
+#include <csignal>
+#include <unistd.h>
+#include <iostream>
+
+#include "Rover.h"
+#include "Globals.h"
+#include "simulator/world_interface.h"
+#include "Networking/CANUtils.h"
+#include "Networking/ParseCAN.h"
+
+extern "C"
+{
+    #include "HindsightCAN/CANMotorUnit.h"
+    #include "HindsightCAN/CANSerialNumbers.h"
+    #include "HindsightCAN/CANCommon.h"
+    #include "HindsightCAN/CANPacket.h"
+}
+
+const double CONTROL_HZ = 10.0;
+const uint8_t motor_group_id = DEVICE_GROUP_MOTOR_CONTROL;
+
+void cleanup(int signum) {
+  std::cout << "Interrupted\n";
+  CANPacket p;
+  AssembleGroupBroadcastingEmergencyStopPacket(&p, motor_group_id, ESTOP_ERR_GENERAL);
+  sendCANPacket(p);
+  exit(0);
+}
+
+int main(int argc, char** argv)
+{
+    world_interface_init();
+    InitializeRover(MOTOR_UNIT_MODE_PID);
+    struct timeval tp0, tp_start;
+
+    // todo add this to our makefile
+    // todo how do we find the PPJR for each motor?
+
+    signal(SIGINT, cleanup);
+
+    std::string str;
+    std::cout << "Enter motor serial > ";
+    std::getline(std::cin, str);
+    int raw_serial = std::stoi(str);
+    uint8_t serial = (uint8_t) serial;
+    std::string motor_name = motor_group[serial];
+    std::cout << "Enter coefficients for motor " << motor_name << ":\n";
+    std::cout << "P > ";
+    std::getline(std::cin, str);
+    int p_coeff = std::stoi(str);
+    std::cout << "I > ";
+    std::getline(std::cin, str);
+    int i_coeff = std::stoi(str);
+    std::cout << "D > ";
+    std::getline(std::cin, str);
+    int d_coeff = std::stoi(str);
+
+    CANPacket p;
+    AssemblePSetPacket(&p, motor_group_id, serial, p_coeff);
+    sendCANPacket(p);
+    AssembleISetPacket(&p, motor_group_id, serial, i_coeff);
+    sendCANPacket(p);
+    AssembleDSetPacket(&p, motor_group_id, serial, d_coeff);
+    sendCANPacket(p);
+
+    double timestep = 0.0;
+    double period = 3.0;
+    double amplitude = 15 * 1000.0; // in 1000th's of degrees
+            // (doesn't make sense for hand motor, but that doesn't use PID)
+    int32_t angle_target = 0;
+    double acc_error = 0.0;
+    int total_steps = 0;
+
+    while (total_steps < 30)
+    {
+        gettimeofday(&tp_start, NULL);
+
+        while (recvCANPacket(&p) != 0) {
+            ParseCANPacket(p);
+        }
+
+        int32_t current_angle = Globals::status_data[motor_name]["angular_position"];
+        double difference = (current_angle - angle_target) / 1000.0;
+        acc_error += difference * difference;
+        printf("Step %02d: target %05d actual %05d\n", total_steps, angle_target, current_angle);
+        total_steps += 1;
+
+        timestep += 1.0/CONTROL_HZ;
+        angle_target = (int32_t) round(amplitude * sin(2*M_PI * timestep / period));
+
+        AssemblePIDTargetSetPacket(&p, motor_group_id, serial, angle_target);
+        sendCANPacket(p);
+
+        gettimeofday(&tp0, NULL);
+        long elapsedUsecs = (tp0.tv_sec - tp_start.tv_sec) * 1000 * 1000 + (tp0.tv_usec - tp_start.tv_usec);
+        long desiredUsecs = 1000 * 1000 / CONTROL_HZ;
+        if (desiredUsecs - elapsedUsecs > 0) {
+            usleep(desiredUsecs - elapsedUsecs);
+        } else {
+            std::cout << "Can't keep up with control frequency! Desired " << desiredUsecs/1000 << " elapsed " << elapsedUsecs/1000 << std::endl;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
There are three CAN messages we need to send to the motor boards in order to initialize encoder sensor measurements. This PR makes it so we send those messages automatically when starting the `Rover` executable.

This PR also adds a script to help tune PID coefficients. The script sends a trajectory of target angles (currently a sine wave of amplitude 15 degrees and period 3 seconds) to the motor boards and measures the actual angles as reported by the encoders. The idea is that a human operator will run this script several times for each motor, tweaking the PID coefficients, until we get good trajectory tracking performance. I have not actually tested this script yet, because we haven't yet gotten good data from the encoders.

In the course of compiling this script, I reorganized our CMakeLists.txt.