### PR TITLE
Fix some bugs for PID control

### DIFF
--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -8,7 +8,8 @@ extern "C"
 }
 
 const bool TEST_MODE_SET = false;
-const bool TEST_PWM = true;
+const bool TEST_PWM = false;
+const bool TEST_PID = true;
 
 int main() {
   InitializeCANSocket();
@@ -38,6 +39,38 @@ int main() {
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x0);
       sendCANPacket(p);
       AssemblePWMDirSetPacket(&p, motor_group, (uint8_t) serial, (int16_t) pwm);
+      sendCANPacket(p);
+    }
+    if (TEST_PID) {
+      std::cout << "Enter motor serial > ";
+      std::getline(std::cin, str);
+      int serial = std::stoi(str);
+
+      std::cout << "P > ";
+      std::getline(std::cin, str);
+      int p_coeff = std::stoi(str);
+      std::cout << "I > ";
+      std::getline(std::cin, str);
+      int i_coeff = std::stoi(str);
+      std::cout << "D > ";
+      std::getline(std::cin, str);
+      int d_coeff = std::stoi(str);
+
+      std::cout << "Enter PID target (in 1000ths of degrees) > ";
+      std::getline(std::cin, str);
+      int angle_target = std::stoi(str);
+
+      CANPacket p;
+      AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x1);
+      sendCANPacket(p);
+      AssemblePSetPacket(&p, motor_group, (uint8_t) serial, p_coeff);
+      sendCANPacket(p);
+      AssembleISetPacket(&p, motor_group, (uint8_t) serial, i_coeff);
+      sendCANPacket(p);
+      AssembleDSetPacket(&p, motor_group, (uint8_t) serial, d_coeff);
+      sendCANPacket(p);
+
+      AssemblePIDTargetSetPacket(&p, motor_group, (uint8_t) serial, angle_target);
       sendCANPacket(p);
     }
   }

--- a/src/Rover.h
+++ b/src/Rover.h
@@ -3,5 +3,5 @@
 
 #include <stdint.h>
 
-void InitializeRover(uint8_t arm_mode);
+void InitializeRover(uint8_t arm_mode, bool zero_encoders);
 int rover_loop(int argc, char** argv);

--- a/src/TunePID.cpp
+++ b/src/TunePID.cpp
@@ -34,7 +34,7 @@ void cleanup(int signum) {
 int main(int argc, char** argv)
 {
     world_interface_init();
-    InitializeRover(MOTOR_UNIT_MODE_PID);
+    InitializeRover(MOTOR_UNIT_MODE_PID, false);
     struct timeval tp0, tp_start;
 
     // TODO: Before running this script, make sure the PPJR is set correctly for each motor
@@ -46,9 +46,9 @@ int main(int argc, char** argv)
     std::cout << "Enter motor serial > ";
     std::getline(std::cin, str);
     int raw_serial = std::stoi(str);
-    uint8_t serial = (uint8_t) serial;
+    uint8_t serial = (uint8_t) raw_serial;
     std::string motor_name = motor_group[serial];
-    std::cout << "Enter coefficients for motor " << motor_name << ":\n";
+    printf("Enter coefficients for motor [%s] (serial %d):\n", motor_name.c_str(), serial);
     std::cout << "P > ";
     std::getline(std::cin, str);
     int p_coeff = std::stoi(str);
@@ -71,7 +71,13 @@ int main(int argc, char** argv)
     double period = 3.0;
     double amplitude = 15 * 1000.0; // in 1000th's of degrees
             // (doesn't make sense for hand motor, but that doesn't use PID)
-    int32_t angle_target = 0;
+
+    usleep(300 * 1000); // wait for encoder position data to arrive
+    while (recvCANPacket(&p) != 0) {
+        ParseCANPacket(p);
+    }
+    int32_t starting_angle = Globals::status_data[motor_name]["angular_position"];
+    int32_t angle_target = starting_angle;
     double acc_error = 0.0;
     int total_steps = 0;
 
@@ -90,7 +96,8 @@ int main(int argc, char** argv)
         total_steps += 1;
 
         timestep += 1.0/CONTROL_HZ;
-        angle_target = (int32_t) round(amplitude * sin(2*M_PI * timestep / period));
+        angle_target = (int32_t) round(amplitude * sin(2*M_PI * timestep / period))
+            + starting_angle;
 
         AssemblePIDTargetSetPacket(&p, motor_group_id, serial, angle_target);
         sendCANPacket(p);


### PR DESCRIPTION
Changes TunePID script to allow starting at a nonzero angle (which is
important to avoid possible issues with negative underflow).

Also makes it possible to set a different PPJR for each arm joint.

Also adds a simpler script (in FakeCANBoard.cpp) for testing PID
control with constant angles rather than time-varying angles.