### PR TITLE
More changes to PID testing code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -155,7 +155,7 @@ include(CTest)
 include(Catch)
 target_link_libraries(tests ${sfml_libs} ${rclcpp_LIBRARIES} ${geometry_msgs_LIBRARIES})
 target_link_libraries(tests Catch2::Catch2)
-target_link_libraries(tests ${OpenCV_LIBS})
+target_link_libraries(tests ${OpenCV_LIBS} opencv_aruco)
 catch_discover_tests(tests)
 
 add_library(lidar_base

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -7,58 +7,49 @@ extern "C"
     #include "../HindsightCAN/CANMotorUnit.h"
 }
 
-const bool TEST_MODE_SET = false;
-const bool TEST_PWM = false;
-const bool TEST_PID = true;
+constexpr int TEST_MODE_SET = 0;
+constexpr int TEST_PWM = 1;
+constexpr int TEST_PID = 2;
+
+int prompt(const char *msg) {
+  std::string str;
+  std::cout << msg << " > ";
+  std::getline(std::cin, str);
+  int val = std::stoi(str);
+  return val;
+}
 
 int main() {
   InitializeCANSocket();
 
-  std::string str;
   CANPacket p;
   uint8_t motor_group = 0x04;
+  int test_type = prompt("What are you testing? (0 for MODE SET, 1 for PWM, 2 for PID)");
+
   while(1) {
-    if (TEST_MODE_SET) {
-      std::cout << "Enter motor serial > ";
-      std::getline(std::cin, str);
-      int serial = std::stoi(str);
-      std::cout << "Enter mode (0 for PWM, 1 for PID) > ";
-      std::getline(std::cin, str);
-      int mode = std::stoi(str);
+    if (test_type == TEST_MODE_SET) {
+      int serial = prompt("Enter motor serial");
+      int mode = prompt("Enter mode (0 for PWM, 1 for PID)");
       std::cout << "got " << serial << " and " << mode << std::endl;
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) mode);
       sendCANPacket(p);
     }
-    if (TEST_PWM) {
-      std::cout << "Enter motor serial > ";
-      std::getline(std::cin, str);
-      int serial = std::stoi(str);
-      std::cout << "Enter PWM > ";
-      std::getline(std::cin, str);
-      int pwm = std::stoi(str);
+    if (test_type == TEST_PWM) {
+      int serial = prompt("Enter motor serial");
+      int pwm = prompt("Enter PWM");
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x0);
       sendCANPacket(p);
       AssemblePWMDirSetPacket(&p, motor_group, (uint8_t) serial, (int16_t) pwm);
       sendCANPacket(p);
     }
-    if (TEST_PID) {
-      std::cout << "Enter motor serial > ";
-      std::getline(std::cin, str);
-      int serial = std::stoi(str);
+    if (test_type == TEST_PID) {
+      int serial = prompt("Enter motor serial");
 
-      std::cout << "P > ";
-      std::getline(std::cin, str);
-      int p_coeff = std::stoi(str);
-      std::cout << "I > ";
-      std::getline(std::cin, str);
-      int i_coeff = std::stoi(str);
-      std::cout << "D > ";
-      std::getline(std::cin, str);
-      int d_coeff = std::stoi(str);
+      int p_coeff = prompt("P");
+      int i_coeff = prompt("I");
+      int d_coeff = prompt("D");
 
-      std::cout << "Enter PID target (in 1000ths of degrees) > ";
-      std::getline(std::cin, str);
-      int angle_target = std::stoi(str);
+      int angle_target = prompt("Enter PID target (in 1000ths of degrees)");
 
       CANPacket p;
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x1);

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -25,17 +25,17 @@ int main() {
   CANPacket p;
   uint8_t motor_group = 0x04;
   int test_type = prompt("What are you testing? (0 for MODE SET, 1 for PWM, 2 for PID)");
+  int serial = prompt("Enter motor serial");
 
   while(1) {
     if (test_type == TEST_MODE_SET) {
-      int serial = prompt("Enter motor serial");
+      serial = prompt("Enter motor serial");
       int mode = prompt("Enter mode (0 for PWM, 1 for PID)");
       std::cout << "got " << serial << " and " << mode << std::endl;
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) mode);
       sendCANPacket(p);
     }
     if (test_type == TEST_PWM) {
-      int serial = prompt("Enter motor serial");
       int pwm = prompt("Enter PWM");
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x0);
       sendCANPacket(p);
@@ -43,24 +43,25 @@ int main() {
       sendCANPacket(p);
     }
     if (test_type == TEST_PID) {
-      int serial = prompt("Enter motor serial");
+      // Don't send all five packets at once. On some motor boards, the CAN buffer
+      // only fits four packets.
 
-      int p_coeff = prompt("P");
-      int i_coeff = prompt("I");
-      int d_coeff = prompt("D");
-
-      int angle_target = prompt("Enter PID target (in 1000ths of degrees)");
-
-      CANPacket p;
       AssembleModeSetPacket(&p, motor_group, (uint8_t) serial, (uint8_t) 0x1);
       sendCANPacket(p);
+
+      int p_coeff = prompt("P");
       AssemblePSetPacket(&p, motor_group, (uint8_t) serial, p_coeff);
       sendCANPacket(p);
+
+      int i_coeff = prompt("I");
       AssembleISetPacket(&p, motor_group, (uint8_t) serial, i_coeff);
       sendCANPacket(p);
+
+      int d_coeff = prompt("D");
       AssembleDSetPacket(&p, motor_group, (uint8_t) serial, d_coeff);
       sendCANPacket(p);
 
+      int angle_target = prompt("Enter PID target (in 1000ths of degrees)");
       AssemblePIDTargetSetPacket(&p, motor_group, (uint8_t) serial, angle_target);
       sendCANPacket(p);
     }

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -31,13 +31,13 @@ bool sendError(std::string const &msg)
   error_message["status"] = "error";
   error_message["msg"] = msg;
   sendBaseStationPacket(error_message.dump());
-  log(LOG_ERROR, "%s", error_message.dump());
+  log(LOG_ERROR, "%s\n", error_message.dump().c_str());
   return false;
 }
 
 bool ParseBaseStationPacket(char const* buffer)
 {
-  log(LOG_DEBUG, "Message from base station: %s", buffer);
+  log(LOG_DEBUG, "Message from base station: %s\n", buffer);
   json parsed_message;
   try
   {
@@ -56,7 +56,7 @@ bool ParseBaseStationPacket(char const* buffer)
   {
     return sendError("Could not find message type");
   }
-  log(LOG_DEBUG, "Message type: %s", type);
+  log(LOG_DEBUG, "Message type: %s\n", type.c_str());
 
   bool success = false;
   if (type == "estop") {

--- a/src/Networking/ParseCAN.cpp
+++ b/src/Networking/ParseCAN.cpp
@@ -90,6 +90,6 @@ void ParseCANPacket(CANPacket p)
         // TODO is this data sometimes unsigned?
         Globals::status_data[device_name][telem_type] = val;
     } else {
-        log(LOG_WARN, "Got packet of non-telemetry ID\n");
+        log(LOG_WARN, "Got packet of non-telemetry ID %d\n", GetPacketID(&p));
     }
 }

--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -68,7 +68,7 @@ bool ParseMotorPacket(json &message)
     return sendError("Unrecognized motor " + motor);
   }
 
-  log(LOG_DEBUG, "Parsing motor packet for motor %s", motor);
+  log(LOG_DEBUG, "Parsing motor packet for motor %s\n", motor.c_str());
 
   for (int key_idx = 0; key_idx < possible_keys["motor"].size(); key_idx++)
   {

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -98,6 +98,7 @@ const double CONTROL_HZ = 10.0;
 
 int rover_loop(int argc, char **argv)
 {
+    LOG_LEVEL = LOG_INFO;
     world_interface_init();
     rclcpp::init(0, nullptr);
     // Ctrl+C doesn't stop the simulation without this line

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -24,8 +24,10 @@ extern "C"
 
 const std::vector<uint32_t> arm_PPJRs = {
     360 * 1000, // base, unmeasured
-    360 * 1000, // shoulder, unmeasured
+
+    180 * 1000, // shoulder, rough estimate
     36 * 1000, // elbow, rough estimate
+
     360 * 1000, // forearm, unmeasured
     360 * 1000, // diff_left, unmeasured
     360 * 1000 // diff_right, unmeasured

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include "log.h"
 
-int LOG_LEVEL = LOG_INFO;
+int LOG_LEVEL = LOG_TRACE;
 
 void log(int level, const char *fmt, ...)
 {


### PR DESCRIPTION
A bunch of code changes that I found useful while doing on-rover testing today.

- Implement sending actual e-stop packets
- Easier-to-use FakeCANBoard script
- Additional logging messages in the Rover.cpp main loop
- some other small changes