### PR TITLE
Do planning in separate thread

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -432,9 +432,8 @@ void Autonomous::autonomyIter()
 			pending_plan =
 				std::async(std::launch::async, &computePlan, collide_func, point_t_goal);
 		}
-		// if there is a plan pending, wait maximum 1ms for it to be ready.
-		// TODO possibly change this time if we want it to be shorter.
-		else if(pending_plan.wait_for(std::chrono::milliseconds(1)) == std::future_status::ready){
+		// if there is a plan pending, check if it is ready.
+		else if(pending_plan.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready){
 			// plan is ready; retrieve it and check if the cost is satisfactory.
 			// upon calling get(), pending_plan.valid() will return false, so if we reject this
 			// plan another will be computed.

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -54,6 +54,7 @@ Autonomous::Autonomous(const URCLeg &_target, double controlHz)
 		control_state(ControlState::FAR_FROM_TARGET_POSE),
 		time_since_plan(0),
 		plan(0,2),
+        pending_plan(),
 		plan_cost(INFINITE_COST),
 		plan_base({0,0,0}),
 		plan_idx(0),

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <vector>
 #include <future>
-#include <thread>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <future>
+#include <thread>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
@@ -69,6 +71,7 @@ private:
 	ControlState control_state;
 	int time_since_plan;
 	plan_t plan;
+	std::future<plan_t> pending_plan;
 	double plan_cost;
 	pose_t plan_base;
 	int plan_idx;


### PR DESCRIPTION
Changed the autonomous code to compute the plan in a separate thread using `std::async`; I opted to make it the caller's responsibility to do planning in a different thread just so I didn't have to change any of the planning code itself. The `Autonomous` class now holds a `std::future` object which represents a pending plan, and every time it would recompute a plan it checks if one is already pending before dispatching a thread to compute one. Tested using the simulator and it seems to work fine, but I don't have much experience with the planning code so let me know if anything is wrong.