### PR TITLE
Networking improvements

### DIFF
--- a/DEFAULT_FASTRTPS_PROFILES.xml
+++ b/DEFAULT_FASTRTPS_PROFILES.xml
@@ -14,6 +14,16 @@
                     </locator> 
                     <locator> 
                         <udpv4>
+                          <address>192.168.133.1</address> 
+                        </udpv4>
+                    </locator> 
+                    <locator> 
+                        <udpv4>
+                          <address>192.168.133.12</address> 
+                        </udpv4>
+                    </locator> 
+                    <locator> 
+                        <udpv4>
                           <address>40.40.40.40</address> 
                         </udpv4>
                     </locator> 

--- a/src/Networking/Network.cpp
+++ b/src/Networking/Network.cpp
@@ -8,6 +8,7 @@
 
 #include <net/if.h>
 #include <cstring>
+#include <cstdlib>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -23,6 +24,25 @@ bool InitializeBaseStationSocket()
 {
   if (connected) return connected;
 
+  char *ssh_client = std::getenv("SSH_CLIENT");
+  const char *server_ip;
+  if (ssh_client == nullptr) {
+      log(LOG_WARN, "SSH_CLIENT environment variable is not set: defaulting server IP to 127.0.0.1");
+      server_ip = "127.0.0.1";
+  } else {
+      int i = 0;
+      log(LOG_DEBUG, "Got ssh client %s\n", ssh_client);
+      char c;
+      while ((c = ssh_client[i++]) != '\0') {
+          if (c == ' ') {
+              ssh_client[i-1] = '\0';
+              break;
+          }
+      }
+      server_ip = ssh_client;
+      log(LOG_INFO, "Setting server IP to %s\n", server_ip);
+  }
+
   if ((base_station_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
   {
     if (!failed_once) {
@@ -37,7 +57,7 @@ bool InitializeBaseStationSocket()
 
   servaddr.sin_family = AF_INET;
   servaddr.sin_port = htons(PORT);
-  servaddr.sin_addr.s_addr = inet_addr(SERVER_IP);
+  servaddr.sin_addr.s_addr = inet_addr(server_ip);
 
   if (connect(base_station_fd, (struct sockaddr*)&servaddr, sizeof(servaddr)) < 0)
   {

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -24,9 +24,9 @@ extern "C"
 }
 
 constexpr std::array<uint32_t,6> arm_PPJRs = {
-    17 * 1000, // base, rough estimate
+    17 * 1000, // base, estimate
 
-    1200 * 1000, // shoulder, estimate, TODO there's some bug with setting PPJR for this board
+    20 * 1000, // shoulder, estimate
     36 * 1000, // elbow, rough estimate
 
     360 * 1000, // forearm, unmeasured


### PR DESCRIPTION
The IP addresses of the base station and the rover are different on the antenna network. This PR adds those IP addresses to the DEFAULT_FASTRTPS_PROFILES.xml (used by ROS2 for peer discovery) and changes the rover initialization code to pull the server IP address from the environment variable `SSH_CLIENT` (which makes it so we don't need to recompile the program every time the server IP address changes).

There's also a small unrelated change: we fixed the PPJR bug on the shoulder board, so we now have a better estimate for the PPJR for that joint.