### PR TITLE
Forward kinematics

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <string>
 
-// NOTE(sasha): Everything in here should be marked constexpr.
 namespace Constants
 {
 constexpr size_t PACKET_PAYLOAD_SIZE = 8;
@@ -16,10 +15,12 @@ constexpr double WHEEL_BASE = 2. / 3.;
 // Joint limits
 constexpr double ARM_BASE_MIN = -M_PI / 2;
 constexpr double ARM_BASE_MAX = M_PI / 2;
+//constexpr double SHOULDER_MIN = M_PI / 2; // TODO mechanical problem with the moon gear.
+//                                             Use this value during actual rover operation.
 constexpr double SHOULDER_MIN = 0.0;
 constexpr double SHOULDER_MAX = M_PI * 5. / 6.; // Can't quite lie flat
 constexpr double ELBOW_MIN = 0.0;
-constexpr double ELBOW_MAX = M_PI;
+constexpr double ELBOW_MAX = M_PI * 29./30.; // I think this should prevent self-collisions
 
 const std::string AR_CAMERA_CONFIG_PATH = "../camera-config/MastCameraCalibration.yml";
 } // namespace Constants

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -1,27 +1,58 @@
 
+#include "IK.h"
 #include "ParseBaseStation.h"
 #include "motor_interface.h"
 #include "../Constants.h"
+#include "../Globals.h"
 #include <iostream>
 
-// TODO check with electronics to see if this is accurate
-double RAD_PER_INT = (2*M_PI) / ((double) (1<<16));
+// Angular positions from the motor boards are given in millidegrees
+double RAD_PER_INT = (2*M_PI) / (360*1000.0);
 
-int32_t radToInt(double d, double offset, int32_t sign_flip)
+// See IK.h for explanation of sign / offset conventions
+//                                     arm_base, shoulder,                elbow
+const std::array<int, 3> sign_flips = {1,        1,                       1};
+const std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Constants::ELBOW_MAX};
+
+int32_t radToInt(double d, int motor_serial)
 {
+  double offset = offsets[motor_serial];
+  int sign_flip = sign_flips[motor_serial];
   int32_t i = sign_flip * (d - offset) / RAD_PER_INT;
   return i;
 }
 
-double intToRad(int32_t i, double offset, int32_t sign_flip)
+double intToRad(int32_t i, int motor_serial)
 {
+  double offset = offsets[motor_serial];
+  int sign_flip = sign_flips[motor_serial];
   double d = sign_flip * i * RAD_PER_INT + offset;
   return d;
 }
 
+std::array<double, 3> forward_kinematics() {
+  // This function assumes we already received encoder data from each motor
+  int arm_base_pos = Globals::status_data["arm_base"]["angular_position"];
+  int shoulder_pos = Globals::status_data["shoulder"]["angular_position"];
+  int elbow_pos = Globals::status_data["elbow"]["angular_position"];
+  // See IK.h for explanation of sign / offset conventions
+  double arm_base = intToRad(arm_base_pos, 1);
+  double shoulder = intToRad(shoulder_pos, 2);
+  double elbow = intToRad(elbow_pos, 3);
+  double r1 = Constants::SHOULDER_LENGTH * cos(shoulder);
+  double r2 = Constants::ELBOW_LENGTH * cos(shoulder-elbow);
+  double z1 = Constants::SHOULDER_LENGTH * sin(shoulder);
+  double z2 = Constants::ELBOW_LENGTH * sin(shoulder-elbow);
+  double z = z1+z2;
+  double r = r1+r2;
+  double x = r * cos(arm_base);
+  double y = r * sin(arm_base);
+  return {x,y,z};
+}
+
 bool ParseIKPacket(json &message) {
-  double ELBOW_LENGTH = Constants::ELBOW_LENGTH;
-  double SHOULDER_LENGTH = Constants::SHOULDER_LENGTH;
+  const double ELBOW_LENGTH = Constants::ELBOW_LENGTH;
+  const double SHOULDER_LENGTH = Constants::SHOULDER_LENGTH;
   if (message["wrist_base_target"] != nullptr)
   {
     json target = message["wrist_base_target"];
@@ -38,6 +69,8 @@ bool ParseIKPacket(json &message) {
     double baseAngle = atan2(y, x);
     double forward = sqrt(x*x + y*y);
     double height = z;
+    // TODO right now we require the base angle to be within 90 degrees of forward.
+    // This avoids some gimbal lock issues but limits the targets we can reach.
     if (baseAngle > M_PI/2)
     {
       baseAngle -= M_PI;
@@ -74,21 +107,21 @@ bool ParseIKPacket(json &message) {
     // Don't send these packets until we're sure the IK problem is feasible
     json base_packet = {{"type", "motor"},
                         {"motor", "arm_base"},
-                        {"PID target", radToInt(baseAngle, 0, 1)}}; // TODO offset, flip
+                        {"PID target", radToInt(baseAngle, 1)}}; // TODO offset, flip
     if (!ParseMotorPacket(base_packet))
     {
       return false;
     }
     json shoulder_packet = {{"type", "motor"},
                             {"motor", "shoulder"},
-                            {"PID target", radToInt(shoulderAngle, 0, 1)}};
+                            {"PID target", radToInt(shoulderAngle, 2)}};
     if (!ParseMotorPacket(shoulder_packet))
     {
       return false;
     }
     json elbow_packet = {{"type", "motor"},
                          {"motor", "elbow"},
-                         {"PID target", radToInt(elbowAngle, 0, 1)}};
+                         {"PID target", radToInt(elbowAngle, 3)}};
     if (!ParseMotorPacket(elbow_packet))
     {
       return false;

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -17,7 +17,7 @@ const std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Consta
 
 int32_t radToInt(double d, int motor_serial)
 {
-  if (motor_serial < 1 || motor_serial > 3)
+  if (!motorSupportsPID(motor_serial))
   {
     log(LOG_ERROR, "Invalid motor serial %d for radToInt\n", motor_serial);
     return 0;
@@ -30,7 +30,7 @@ int32_t radToInt(double d, int motor_serial)
 
 double intToRad(int32_t i, int motor_serial)
 {
-  if (motor_serial < 1 || motor_serial > 3)
+  if (!motorSupportsPID(motor_serial))
   {
     log(LOG_ERROR, "Invalid motor serial %d for intToRad\n", motor_serial);
     return 0;
@@ -119,7 +119,7 @@ bool ParseIKPacket(json &message) {
     // Don't send these packets until we're sure the IK problem is feasible
     json base_packet = {{"type", "motor"},
                         {"motor", "arm_base"},
-                        {"PID target", radToInt(baseAngle, 1)}}; // TODO offset, flip
+                        {"PID target", radToInt(baseAngle, 1)}};
     if (!ParseMotorPacket(base_packet))
     {
       return false;

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -12,8 +12,8 @@ double RAD_PER_INT = (2*M_PI) / (360*1000.0);
 
 // See IK.h for explanation of sign / offset conventions
 //                                     arm_base, shoulder,                elbow
-const std::array<int, 3> sign_flips = {1,        1,                       1};
-const std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Constants::ELBOW_MAX};
+constexpr std::array<int, 3> sign_flips = {1,        1,                       1};
+constexpr std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Constants::ELBOW_MAX};
 
 int32_t radToInt(double d, int motor_serial)
 {
@@ -63,8 +63,8 @@ std::array<double, 3> forward_kinematics() {
 }
 
 bool ParseIKPacket(json &message) {
-  const double ELBOW_LENGTH = Constants::ELBOW_LENGTH;
-  const double SHOULDER_LENGTH = Constants::SHOULDER_LENGTH;
+  constexpr double ELBOW_LENGTH = Constants::ELBOW_LENGTH;
+  constexpr double SHOULDER_LENGTH = Constants::SHOULDER_LENGTH;
   if (message["wrist_base_target"] != nullptr)
   {
     json target = message["wrist_base_target"];

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -17,19 +17,27 @@ const std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Consta
 
 int32_t radToInt(double d, int motor_serial)
 {
+  if (motor_serial < 1 || motor_serial > 3)
+  {
+    log(LOG_ERROR, "Invalid motor serial %d for radToInt\n", motor_serial);
+    return 0;
+  }
   double offset = offsets[motor_serial-1];
   int sign_flip = sign_flips[motor_serial-1];
   int32_t i = sign_flip * (d - offset) / RAD_PER_INT;
-  log(LOG_TRACE, "radToInt %f %d %f %d %d\n", d, motor_serial, offset, sign_flip, i);
   return i;
 }
 
 double intToRad(int32_t i, int motor_serial)
 {
+  if (motor_serial < 1 || motor_serial > 3)
+  {
+    log(LOG_ERROR, "Invalid motor serial %d for intToRad\n", motor_serial);
+    return 0;
+  }
   double offset = offsets[motor_serial-1];
   int sign_flip = sign_flips[motor_serial-1];
   double d = sign_flip * i * RAD_PER_INT + offset;
-  log(LOG_TRACE, "intToRad %d %d %f %d %f\n", i, motor_serial, offset, sign_flip, d);
   return d;
 }
 

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -4,6 +4,7 @@
 #include "motor_interface.h"
 #include "../Constants.h"
 #include "../Globals.h"
+#include "../log.h"
 #include <iostream>
 
 // Angular positions from the motor boards are given in millidegrees
@@ -16,17 +17,19 @@ const std::array<double, 3> offsets = {0.0,      Constants::SHOULDER_MAX, Consta
 
 int32_t radToInt(double d, int motor_serial)
 {
-  double offset = offsets[motor_serial];
-  int sign_flip = sign_flips[motor_serial];
+  double offset = offsets[motor_serial-1];
+  int sign_flip = sign_flips[motor_serial-1];
   int32_t i = sign_flip * (d - offset) / RAD_PER_INT;
+  log(LOG_TRACE, "radToInt %f %d %f %d %d\n", d, motor_serial, offset, sign_flip, i);
   return i;
 }
 
 double intToRad(int32_t i, int motor_serial)
 {
-  double offset = offsets[motor_serial];
-  int sign_flip = sign_flips[motor_serial];
+  double offset = offsets[motor_serial-1];
+  int sign_flip = sign_flips[motor_serial-1];
   double d = sign_flip * i * RAD_PER_INT + offset;
+  log(LOG_TRACE, "intToRad %d %d %f %d %f\n", i, motor_serial, offset, sign_flip, d);
   return d;
 }
 
@@ -39,6 +42,7 @@ std::array<double, 3> forward_kinematics() {
   double arm_base = intToRad(arm_base_pos, 1);
   double shoulder = intToRad(shoulder_pos, 2);
   double elbow = intToRad(elbow_pos, 3);
+  log(LOG_DEBUG, "Running forward kinematics for %f %f %f\n", arm_base, shoulder, elbow);
   double r1 = Constants::SHOULDER_LENGTH * cos(shoulder);
   double r2 = Constants::ELBOW_LENGTH * cos(shoulder-elbow);
   double z1 = Constants::SHOULDER_LENGTH * sin(shoulder);

--- a/src/Networking/IK.h
+++ b/src/Networking/IK.h
@@ -12,7 +12,9 @@ bool ParseIKPacket(json &message);
 // are approximately (0,pi,pi).
 // Arm base positive direction is counterclockwise (viewed from above the rover).
 // Shoulder, elbow positive direction is towards the stowed limit switch.
-int32_t radToInt(double d, double offset, int32_t sign_flip);
+int32_t radToInt(double d, int motor_serial);
 
 // Inverse of the above
-double intToRad(int32_t i, double offset, int32_t sign_flip);
+double intToRad(int32_t i, int motor_serial);
+
+std::array<double, 3> forward_kinematics();

--- a/src/Networking/motor_interface.h
+++ b/src/Networking/motor_interface.h
@@ -6,3 +6,4 @@ using nlohmann::json;
 
 bool ParseMotorPacket(json &message);
 void incrementArm();
+bool motorSupportsPID(int motor_serial);

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -201,30 +201,40 @@ void assert_IK_equals(double base, double shoulder, double elbow)
     CANPacket p;
     p = popPIDPkt();
     int base_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(base_val, 0) == Approx(base));
+    REQUIRE(intToRad(base_val, 0) == Approx(base).margin(0.01));
 
     p = popPIDPkt();
     int shoulder_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(shoulder_val, 1) == Approx(shoulder));
+    REQUIRE(intToRad(shoulder_val, 1) == Approx(shoulder).margin(0.01));
 
     p = popPIDPkt();
     int elbow_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(elbow_val, 2) == Approx(elbow));
+    REQUIRE(intToRad(elbow_val, 2) == Approx(elbow).margin(0.01));
 }
 
 void set_radian_arm_angles(double arm_base, double shoulder, double elbow)
 {
-    Globals::status_data["arm_base"]["angular_position"] = radToInt(arm_base, 0);
-    Globals::status_data["shoulder"]["angular_position"] = radToInt(shoulder, 1);
-    Globals::status_data["elbow"]["angular_position"]    = radToInt(elbow, 2);
+    Globals::status_data["arm_base"]["angular_position"] = radToInt(arm_base, 1);
+    Globals::status_data["shoulder"]["angular_position"] = radToInt(shoulder, 2);
+    Globals::status_data["elbow"]["angular_position"]    = radToInt(elbow, 3);
 }
 
 void assert_FK_equals(double x, double y, double z)
 {
     std::array<double, 3> xyz = forward_kinematics();
-    REQUIRE(x == Approx(xyz[0]));
-    REQUIRE(y == Approx(xyz[1]));
-    REQUIRE(z == Approx(xyz[2]));
+    REQUIRE(x == Approx(xyz[0]).margin(0.01));
+    REQUIRE(y == Approx(xyz[1]).margin(0.01));
+    REQUIRE(z == Approx(xyz[2]).margin(0.01));
+}
+
+TEST_CASE("radToInt and intToRad", "[BaseStation]")
+{
+  for (int i = -360 * 1000; i < 360 * 1000; i += 56565) {
+    for (int serial = 1; serial < 4; serial++) {
+      //printf("%d (serial %d) %f %d\n", i, serial, intToRad(i, serial), radToInt(intToRad(i, serial), serial));
+      REQUIRE(abs(radToInt(intToRad(i, serial), serial) - i) < 5);
+    }
+  }
 }
 
 TEST_CASE("Forward kinematics in stowed position", "[BaseStation]")

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -201,15 +201,15 @@ void assert_IK_equals(double base, double shoulder, double elbow)
     CANPacket p;
     p = popPIDPkt();
     int base_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(base_val, 0) == Approx(base).margin(0.01));
+    REQUIRE(intToRad(base_val, 1) == Approx(base).margin(0.01));
 
     p = popPIDPkt();
     int shoulder_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(shoulder_val, 1) == Approx(shoulder).margin(0.01));
+    REQUIRE(intToRad(shoulder_val, 2) == Approx(shoulder).margin(0.01));
 
     p = popPIDPkt();
     int elbow_val = DecodeBytesToIntMSBFirst(p.data, 1, 5);
-    REQUIRE(intToRad(elbow_val, 2) == Approx(elbow).margin(0.01));
+    REQUIRE(intToRad(elbow_val, 3) == Approx(elbow).margin(0.01));
 }
 
 void set_radian_arm_angles(double arm_base, double shoulder, double elbow)
@@ -242,7 +242,7 @@ TEST_CASE("Forward kinematics in stowed position", "[BaseStation]")
     Globals::status_data["arm_base"]["angular_position"] = 0;
     Globals::status_data["shoulder"]["angular_position"] = 0;
     Globals::status_data["elbow"]["angular_position"] = 0;
-    assert_FK_equals(0.,0.,0.);
+    assert_FK_equals(0.119867, 0., 0.0152843);
 }
 
 TEST_CASE("Forward kinematics at full extension", "[BaseStation]")
@@ -262,7 +262,7 @@ TEST_CASE("Forward kinematics at full extension", "[BaseStation]")
 TEST_CASE("Forward kinematics near the ground", "[BaseStation]")
 {
     set_radian_arm_angles(0.9, 1.1, 2.3);
-    assert_FK_equals(0., 0., 0.);
+    assert_FK_equals(0.326845, 0.411873, -0.117700);
 }
 
 TEST_CASE("Can handle IK packets", "[BaseStation]")
@@ -330,8 +330,8 @@ TEST_CASE("Forward kinematics is the inverse of inverse kinematics", "[BaseStati
     setupEncoders();
     char const *msg = "{\"type\":\"ik\",\"wrist_base_target\":[0.6, -0.3, -0.1]}";
     REQUIRE(ParseBaseStationPacket(msg) == true);
-    assert_IK_equals     (0.927291, 0.534880, 1.342617);
-    set_radian_arm_angles(0.927291, 0.534880, 1.342617);
+    assert_IK_equals     (-0.463647, 1.005327, 2.053642);
+    set_radian_arm_angles(-0.463647, 1.005327, 2.053642);
     assert_FK_equals(0.6, -0.3, -0.1);
 }
 


### PR DESCRIPTION
This PR implements a `forward_kinematics()` method that computes the (x,y,z) position of the hand relative to the arm base, given the current arm angles as reported by the motor encoders. The constants for the lengths of the arm segments and the sign flips for the motor encoders are unknown. I'll do a follow up PR to set those constants after trying things out on the actual rover.