### PR TITLE
Implement autonomous leg sequencing

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -108,6 +108,7 @@ void Autonomous::setNavState(NavState s)
 		if (urc_targets.size() > 0)
 		{
 			setNavState(NavState::GPS);
+			search_target = {urc_targets.front().approx_GPS(0) - PI, urc_targets.front().approx_GPS(1), -PI / 2};
 			setCmdVel(0, 0);
 			Globals::AUTONOMOUS = false;
 		}
@@ -261,7 +262,7 @@ pose_t Autonomous::choose_plan_target(const pose_t &pose)
   {
     return getGPSTargetPose();
   }
-  else if (nav_state == NavState::SEARCH_PATTERN)
+  else if (nav_state == NavState::SEARCH_PATTERN || nav_state == NavState::SEARCH_PATTERN_SECOND_POST)
   {
     return search_target;
   }

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -97,13 +97,18 @@ bool Autonomous::currentLegDone()
 	return nav_state == NavState::DONE;
 }
 
+bool Autonomous::hasNextLeg()
+{
+	return urc_targets.size() > 0;
+}
+
 void Autonomous::startNextLeg()
 {
 	if (!currentLegDone())
 	{
 		log(LOG_INFO, "Cannot start next leg: current leg not done\n");
 	}
-	else if (urc_targets.size() <= 0)
+	else if (!hasNextLeg())
 	{
 		log(LOG_INFO, "Cannot start next leg: no more legs to start\n");
 	}

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -104,10 +104,9 @@ void Autonomous::setNavState(NavState s)
 		rightPostFilter.reset();
 		if (urc_targets.size() > 0)
 		{
-			std::cout << urc_targets.front().approx_GPS(0) << " " << urc_targets.front().approx_GPS(1) << " " << urc_targets.front().approx_GPS(2) << std::endl;
-//			plan_cost = INFINITE_COST;
 			setNavState(NavState::GPS);
-			// TODO SET GLOBALS:AUTONOMOUS TO FALSE SO THAT BASE STATION MUST SEND START MESSAGE TO START THE ROVER
+			setCmdVel(0, 0);
+			Globals::AUTONOMOUS = false;
 		}
 	}
   }

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -54,9 +54,6 @@ public:
 	// Gets the target's coordinate
 	pose_t getGPSTargetPose() const;
 	void autonomyIter();
-	void startNextLeg();
-	bool hasNextLeg();
-	bool currentLegDone();
 
 private:
 	std::queue<URCLeg> urc_targets;
@@ -96,6 +93,7 @@ private:
   void updateLandmarkInformation(const transform_t &invTransform);
   void computeGateTargets(const pose_t &pose);
   void updateSearchTarget();
+	void startNextLeg();
 
 	double getLinearVel(const pose_t &drive_target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &drive_target, const pose_t &pose, double &thetaErr) const;

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -54,6 +54,8 @@ public:
 	// Gets the target's coordinate
 	pose_t getGPSTargetPose() const;
 	void autonomyIter();
+	void startNextLeg();
+	bool currentLegDone();
 
 private:
 	std::queue<URCLeg> urc_targets;

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -55,6 +55,7 @@ public:
 	pose_t getGPSTargetPose() const;
 	void autonomyIter();
 	void startNextLeg();
+	bool hasNextLeg();
 	bool currentLegDone();
 
 private:

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <memory>
 #include <vector>
+#include <queue>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
@@ -45,8 +46,8 @@ constexpr std::array<const char *, 7> NAV_STATE_NAMES ({
 class Autonomous : rclcpp::Node
 {
 public:
-	explicit Autonomous(const URCLeg &urc_target, double controlHz);
-	Autonomous(const URCLeg &urc_target, double controlHz, const pose_t &startPose);
+	explicit Autonomous(const std::queue<URCLeg> &urc_targets, double controlHz);
+	Autonomous(const std::queue<URCLeg> &urc_targets, double controlHz, const pose_t &startPose);
 	// Returns a pair of floats, in heading, speed
 	// Accepts current heading of the robot as parameter
 	// Gets the target's coordinate
@@ -54,7 +55,7 @@ public:
 	void autonomyIter();
 
 private:
-	URCLeg urc_target;
+	std::queue<URCLeg> urc_targets;
 	pose_t search_target;
 	// Gate targets are {NAN, NAN, NAN} if unset and {INF, INF, INF} if reached
 	// gate_targets.second(2) is NAN if targets have not been refined with more accurate landmark measurements

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,9 +53,7 @@ add_library(rover_common SHARED
   worldmap/GlobalMap.cpp
   worldmap/TrICP.cpp
   worldmap/QuadTree.cpp
-  gps/read_usb_gps.cpp
   )
-target_link_libraries(rover_common gps)
 
 add_library(real_base_station SHARED
   Networking/Network.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ add_library(rover_common SHARED
   worldmap/GlobalMap.cpp
   worldmap/TrICP.cpp
   worldmap/QuadTree.cpp
-  #gps/read_usb_gps.cpp
+  gps/read_usb_gps.cpp
   )
 
 add_library(real_base_station SHARED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(rover_common SHARED
   worldmap/GlobalMap.cpp
   worldmap/TrICP.cpp
   worldmap/QuadTree.cpp
+  #gps/read_usb_gps.cpp
   )
 
 add_library(real_base_station SHARED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(rover_common SHARED
   worldmap/QuadTree.cpp
   gps/read_usb_gps.cpp
   )
+target_link_libraries(rover_common gps)
 
 add_library(real_base_station SHARED
   Networking/Network.cpp

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -186,18 +186,18 @@ int rover_loop(int argc, char **argv)
     gettimeofday(&tp_rover_start, NULL);
     for(int iter = 0; /*no termination condition*/; iter++)
     {
-		// For simulator only, comment this out when running on real rover
-		// Wait for user to press enter, then start the next leg
-		// TODO the real rover might want to get this command from the base station
-		// TODO test with only one or two legs so we can finish every leg and see behavior afterwards
-        if (autonomous.currentLegDone()) {
+		// Wait for confirmation to start the next leg
+        if (Globals::AUTONOMOUS && autonomous.currentLegDone() && autonomous.hasNextLeg()) {
+			// For simulator only, change or comment this out when running on real rover
+			// Wait for user to press enter, then start the next leg
+			// TODO the real rover might want to get this command from the base station
 			std::cout << "Press enter to start next leg" << std::endl;
 			// If it takes longer than 10ms to find a newline, it was probably just inputted and we can proceed
 			long elapsedTime = 0;
 			while (elapsedTime < 10 * 1000)
 			{
 				long startTime = getElapsedUsecs(tp_rover_start);
-				// Wait until a newline is found in cin
+				// Blocks until a newline is found in cin
 				std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 				elapsedTime = getElapsedUsecs(tp_rover_start) - startTime;
 			}

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -181,8 +181,6 @@ std::queue<URCLeg> parseGPSLegs(std::string filepath) {
 	return urc_legs;
 }
 
-const double CONTROL_HZ = 10.0;
-
 int rover_loop(int argc, char **argv)
 {
     LOG_LEVEL = LOG_INFO;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -152,6 +152,7 @@ std::queue<URCLeg> parseGPSLegs(std::string filepath) {
 	// left_post_id right_post_id lat lon
 	// Improperly formatted lines (empty lines, comments) are ignored, and text
 	// after the above data on properly formatted lines is ignored
+	// An example can be found at example_gps_legs.txt
 	while (getline(gps_legs, line))
 	{
 		std::istringstream line_stream(line);
@@ -196,24 +197,6 @@ int rover_loop(int argc, char **argv)
     gettimeofday(&tp_rover_start, NULL);
     for(int iter = 0; /*no termination condition*/; iter++)
     {
-		// Wait for confirmation to start the next leg
-        if (Globals::AUTONOMOUS && autonomous.currentLegDone() && autonomous.hasNextLeg()) {
-			// For simulator only, change or comment this out when running on real rover
-			// Wait for user to press enter, then start the next leg
-			// TODO the real rover might want to get this command from the base station
-			std::cout << "Press enter to start next leg" << std::endl;
-			// If it takes longer than 10ms to find a newline, it was probably just inputted and we can proceed
-			long elapsedTime = 0;
-			while (elapsedTime < 10 * 1000)
-			{
-				long startTime = getElapsedUsecs(tp_rover_start);
-				// Blocks until a newline is found in cin
-				std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-				elapsedTime = getElapsedUsecs(tp_rover_start) - startTime;
-			}
-			autonomous.startNextLeg();
-        }
-
         long loopStartElapsedUsecs = getElapsedUsecs(tp_rover_start);
         num_can_packets = 0;
         while (recvCANPacket(&packet) != 0) {

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -4,6 +4,8 @@
 #include <csignal>
 #include <unistd.h>
 #include <array>
+#include <queue>
+#include <fstream>
 
 #include "CommandLineOptions.h"
 #include "Globals.h"
@@ -15,6 +17,7 @@
 #include "Networking/ParseBaseStation.h"
 #include "Autonomous.h"
 #include "simulator/world_interface.h"
+//#include "gps/read_usb_gps.h"
 
 extern "C"
 {
@@ -139,8 +142,28 @@ int rover_loop(int argc, char **argv)
     CANPacket packet;
     // Target location for autonomous navigation
     // Eventually this will be set by communication from the base station
-    int urc_leg = 5;
-    Autonomous autonomous(getLeg(urc_leg), CONTROL_HZ);
+    std::queue<URCLeg> urc_legs;
+	std::ifstream gps_legs("gps_legs.yaml");
+	if (gps_legs)
+	{
+//		for (int i = 0; !gps_legs.eof(); i++)
+//		{
+//			double lon, lat;
+//			gps_legs >> lon >> lat;
+//			point_t leg_map_space = gpsToMeters(lon, lat);
+//			URCLeg leg = {i, i, leg_map_space}; // TODO FIX POST IDS
+//		}
+		std::cout << "Using file" << std::endl;
+	}
+	else
+	{
+		// File does not exist, use simulation legs as defaults
+		for (int i = 0; i < 7; i++)
+		{
+			urc_legs.push(getLeg(i));
+		}
+	}
+    Autonomous autonomous(urc_legs, CONTROL_HZ);
     char buffer[MAXLINE];
     struct timeval tp_loop_end, tp_loop_start, tp_rover_start;
     int num_can_packets = 0;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -134,6 +134,33 @@ void closeSim(int signum)
     raise(SIGTERM);
 }
 
+void parseGPSLegs(std::string filepath) {
+	std::ifstream gps_legs(filepath);
+	if (gps_legs)
+	{
+//		while (!gps_legs.eof())
+//		{
+//			// Assumes the file at filepath is properly formatted
+//			// with each leg on a separate line and of the form
+//			// left_post_id right_post_id lon lat
+//			int left_post_id, right_post_id;
+//			double lon, lat;
+//			gps_legs >> left_post_id >> right_post_id >> lon >> lat;
+//			point_t leg_map_space = gpsToMeters(lon, lat);
+//			URCLeg leg = {left_post_id, right_post_id, leg_map_space};
+//		}
+		std::cout << "Using file" << std::endl;
+	}
+	else
+	{
+		// File does not exist, use simulation legs as defaults
+		for (int i = 0; i < 7; i++)
+		{
+			urc_legs.push(getLeg(i));
+		}
+	}
+}
+
 const double CONTROL_HZ = 10.0;
 
 int rover_loop(int argc, char **argv)
@@ -149,27 +176,7 @@ int rover_loop(int argc, char **argv)
     CANPacket packet;
     // Target location for autonomous navigation
     // Eventually this will be set by communication from the base station
-    std::queue<URCLeg> urc_legs;
-	std::ifstream gps_legs("gps_legs.yaml");
-	if (gps_legs)
-	{
-//		for (int i = 0; !gps_legs.eof(); i++)
-//		{
-//			double lon, lat;
-//			gps_legs >> lon >> lat;
-//			point_t leg_map_space = gpsToMeters(lon, lat);
-//			URCLeg leg = {i, i, leg_map_space}; // TODO FIX POST IDS
-//		}
-		std::cout << "Using file" << std::endl;
-	}
-	else
-	{
-		// File does not exist, use simulation legs as defaults
-		for (int i = 0; i < 7; i++)
-		{
-			urc_legs.push(getLeg(i));
-		}
-	}
+    std::queue<URCLeg> urc_legs = parseGPSLegs("gps_legs.txt");
     Autonomous autonomous(urc_legs, CONTROL_HZ);
     char buffer[MAXLINE];
     struct timeval tp_rover_start;

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -168,6 +168,7 @@ const double CONTROL_HZ = 10.0;
 int rover_loop(int argc, char **argv)
 {
     LOG_LEVEL = LOG_INFO;
+	Globals::AUTONOMOUS = true;
     world_interface_init();
     rclcpp::init(0, nullptr);
     // Ctrl+C doesn't stop the simulation without this line
@@ -187,7 +188,9 @@ int rover_loop(int argc, char **argv)
     {
 		// For simulator only, comment this out when running on real rover
 		// Wait for user to press enter, then start the next leg
-        if (!Globals::AUTONOMOUS) {
+		// TODO the real rover might want to get this command from the base station
+		// TODO test with only one or two legs so we can finish every leg and see behavior afterwards
+        if (autonomous.currentLegDone()) {
 			std::cout << "Press enter to start next leg" << std::endl;
 			// If it takes longer than 10ms to find a newline, it was probably just inputted and we can proceed
 			long elapsedTime = 0;
@@ -198,7 +201,7 @@ int rover_loop(int argc, char **argv)
 				std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 				elapsedTime = getElapsedUsecs(tp_rover_start) - startTime;
 			}
-			Globals::AUTONOMOUS = true;
+			autonomous.startNextLeg();
         }
 
         long loopStartElapsedUsecs = getElapsedUsecs(tp_rover_start);

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -20,7 +20,6 @@
 #include "Networking/motor_interface.h"
 #include "Autonomous.h"
 #include "simulator/world_interface.h"
-#include "gps/read_usb_gps.h"
 
 extern "C"
 {

--- a/src/example_gps_legs.txt
+++ b/src/example_gps_legs.txt
@@ -1,0 +1,12 @@
+Example simulator legs close to UW GPS coordinates
+This file is properly formatted and will be parsed correctly
+
+Leg 1:
+0 -1 47.653116 -122.305619
+
+Leg 2:
+1 2 47.653125 -122.305486
+
+3 4 47.653325 -122.325486 (Leg 3)
+
+5 -1 47.653525 -123.305486

--- a/src/gps/read_usb_gps.h
+++ b/src/gps/read_usb_gps.h
@@ -5,5 +5,4 @@
 
 bool gpsHasFix();
 bool gpsHasFreshData();
-point_t gpsToMeters(double lon, double lat);
 bool startGPSThread();


### PR DESCRIPTION
This PR implements sequencing multiple autonomous legs. When the rover completes a leg, it will start the next leg once the enter key has been pressed in the terminal. This works well in the simulator, but we may want to send this as a command from the base station when used on the real rover.

This also implements parsing autonomous legs from GPS coordinates in a well-formatted file. The filepath can be changed in `Rover.cpp`. If no file is given or the file doesn't exist or contains no valid legs, the default simulator legs are used.

There are also some small refactors included.