### PR TITLE
Enable and fix compiler warnings

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -312,7 +312,7 @@ void Autonomous::updateLandmarkInformation(const transform_t &invTransform)
 	// get landmark data and filter out invalid data points
 	points_t landmarks = readLandmarks();
 	printLandmarks(landmarks);
-	if (urc_targets.front().left_post_id < 0 || urc_targets.front().left_post_id > landmarks.size())
+	if (urc_targets.front().left_post_id < 0 || static_cast<unsigned>(urc_targets.front().left_post_id) > landmarks.size())
 	{
 		log(LOG_ERROR, "Invalid left_post_id %d\n", urc_targets.front().left_post_id);
 		return;
@@ -564,7 +564,7 @@ void Autonomous::autonomyIter()
   if (USE_MAP) {
       if (mapLoopCounter++ > mapBlindPeriod) {
           map.addPoints(toTransform(pose), lidar_scan, mapDoesOverlap ? 0.4 : 0);
-          mapDoesOverlap = lidar_scan.size() > mapOverlapSampleThreshold;
+          mapDoesOverlap = lidar_scan.size() > static_cast<unsigned>(mapOverlapSampleThreshold);
       }
   }
 
@@ -714,7 +714,7 @@ pose_t Autonomous::getGPSTargetPose() const
 static void printLandmarks(points_t& landmarks, int log_level){
 	std::ostringstream stream;
 	stream << "Landmarks: [";
-	for(int i = 0; i < landmarks.size(); i++){
+	for(size_t i = 0; i < landmarks.size(); i++){
 		stream << i << ": {"
 			   << landmarks[i][0] << ", "
 			   << landmarks[i][1] << ", "

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -564,7 +564,7 @@ void Autonomous::autonomyIter()
   if (USE_MAP) {
       if (mapLoopCounter++ > mapBlindPeriod) {
           map.addPoints(toTransform(pose), lidar_scan, mapDoesOverlap ? 0.4 : 0);
-          mapDoesOverlap = lidar_scan.size() > static_cast<unsigned>(mapOverlapSampleThreshold);
+          mapDoesOverlap = lidar_scan.size() > mapOverlapSampleThreshold;
       }
   }
 

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -79,7 +79,7 @@ private:
 	int mapLoopCounter; // number of times the map has been updated
 	int mapBlindPeriod; // the number of loops to wait before starting to build the map
 	bool mapDoesOverlap;
-	int mapOverlapSampleThreshold; // at least these many points required to overlap map
+	unsigned int mapOverlapSampleThreshold; // at least these many points required to overlap map
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr plan_pub;
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr curr_pose_pub;
 	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr drive_target_pub;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall \
 -Wno-unused-variable \
 -Wno-unused-but-set-variable \
 -Wno-unused-result \
--Wno-unused-parameter")
+-Wno-unused-parameter") # -Wconversion") 
 
 enable_testing()
 
@@ -200,7 +200,7 @@ add_subdirectory(ar)
 add_subdirectory(camera)
 
 find_package(Eigen3 REQUIRED)
-include_directories(${EIGEN3_INCLUDE_DIR})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIR})
 
 add_executable(Server
   Networking/Server.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,11 @@ include_directories(${rclcpp_INCLUDE_DIRS})
 include_directories(${geometry_msgs_INCLUDE_DIRS})
 
 add_definitions(-DCHIP_TYPE=CHIP_TYPE_TEMPLATE)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall \
+-Wno-unused-variable \
+-Wno-unused-but-set-variable \
+-Wno-unused-result \
+-Wno-unused-parameter")
 
 enable_testing()
 

--- a/src/CommandLineOptions.cpp
+++ b/src/CommandLineOptions.cpp
@@ -22,4 +22,5 @@ CommandLineOptions ParseCommandLineOptions(int argc, char **argv)
     {
         ParseCommandLineOption(result, argv[i]);
     }
+	return result;
 }

--- a/src/Networking/FakeBaseStation.cpp
+++ b/src/Networking/FakeBaseStation.cpp
@@ -16,7 +16,6 @@ int main()
   pid_t childpid;
   ssize_t n;
   socklen_t len;
-  const int on = 1;
   struct sockaddr_in cliaddr, servaddr;
   void sig_chld(int);
 

--- a/src/Networking/FakeCANBoard.cpp
+++ b/src/Networking/FakeCANBoard.cpp
@@ -25,7 +25,7 @@ int main() {
   CANPacket p;
   uint8_t motor_group = 0x04;
   int test_type = prompt("What are you testing? (0 for MODE SET, 1 for PWM, 2 for PID)");
-  int serial;
+  int serial = 0;
   if (test_type != TEST_MODE_SET) {
       serial = prompt("Enter motor serial");
   }

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -74,7 +74,7 @@ bool ParseIKPacket(json &message) {
       y = target[1];
       z = target[2];
     }
-    catch (json::type_error)
+    catch (json::type_error&)
     {
       return sendError("Could not parse wrist_base_target");
     }

--- a/src/Networking/IK.cpp
+++ b/src/Networking/IK.cpp
@@ -6,6 +6,9 @@
 #include "../Globals.h"
 #include "../log.h"
 #include <iostream>
+extern "C" {
+	#include "../HindsightCAN/CANSerialNumbers.h"
+}
 
 // Angular positions from the motor boards are given in millidegrees
 double RAD_PER_INT = (2*M_PI) / (360*1000.0);
@@ -47,9 +50,9 @@ std::array<double, 3> forward_kinematics() {
   int shoulder_pos = Globals::status_data["shoulder"]["angular_position"];
   int elbow_pos = Globals::status_data["elbow"]["angular_position"];
   // See IK.h for explanation of sign / offset conventions
-  double arm_base = intToRad(arm_base_pos, 1);
-  double shoulder = intToRad(shoulder_pos, 2);
-  double elbow = intToRad(elbow_pos, 3);
+  double arm_base = intToRad(arm_base_pos, DEVICE_SERIAL_MOTOR_BASE);
+  double shoulder = intToRad(shoulder_pos, DEVICE_SERIAL_MOTOR_SHOULDER);
+  double elbow = intToRad(elbow_pos, DEVICE_SERIAL_MOTOR_ELBOW);
   log(LOG_DEBUG, "Running forward kinematics for %f %f %f\n", arm_base, shoulder, elbow);
   double r1 = Constants::SHOULDER_LENGTH * cos(shoulder);
   double r2 = Constants::ELBOW_LENGTH * cos(shoulder-elbow);
@@ -83,11 +86,11 @@ bool ParseIKPacket(json &message) {
     double height = z;
     // TODO right now we require the base angle to be within 90 degrees of forward.
     // This avoids some gimbal lock issues but limits the targets we can reach.
-    if (baseAngle > M_PI/2)
+    if (baseAngle > Constants::ARM_BASE_MAX)
     {
       baseAngle -= M_PI;
       forward *= -1.0;
-    } else if (baseAngle < -M_PI/2) {
+    } else if (baseAngle < Constants::ARM_BASE_MIN) {
       baseAngle += M_PI;
       forward *= -1.0;
     }

--- a/src/Networking/IK.h
+++ b/src/Networking/IK.h
@@ -1,7 +1,8 @@
-
 #pragma once
 
 #include "json.hpp"
+#include <array>
+
 using nlohmann::json;
 bool ParseIKPacket(json &message);
 

--- a/src/Networking/ParseBaseStation.cpp
+++ b/src/Networking/ParseBaseStation.cpp
@@ -46,7 +46,7 @@ bool ParseBaseStationPacket(char const* buffer)
   {
     parsed_message = json::parse(buffer);
   }
-  catch (json::parse_error)
+  catch (json::parse_error&)
   {
     return sendError("Parse error");
   }
@@ -55,7 +55,7 @@ bool ParseBaseStationPacket(char const* buffer)
   {
     type = parsed_message["type"];
   }
-  catch (json::type_error)
+  catch (json::type_error&)
   {
     return sendError("Could not find message type");
   }
@@ -114,7 +114,7 @@ bool ParseEmergencyStop(json &message) {
   {
     release = message["release"];
   }
-  catch (json::type_error)
+  catch (json::type_error&)
   {
     return sendError("Malformatted estop packet");
   }
@@ -134,7 +134,7 @@ bool ParseDrivePacket(json &message) {
     fb = message["forward_backward"];
     lr = message["left_right"];
   }
-  catch (json::type_error)
+  catch (json::type_error&)
   {
     return sendError("Malformatted drive packet");
   }

--- a/src/Networking/Server.cpp
+++ b/src/Networking/Server.cpp
@@ -15,7 +15,6 @@ int main()
 	fd_set rset;
 	ssize_t n;
 	socklen_t len;
-	const int on = 1;
 	struct sockaddr_in cliaddr, servaddr;
 	void sig_chld(int);
 

--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -64,7 +64,7 @@ bool motorSupportsPID(int motor_serial)
 
 int getIndex(const std::vector<std::string> &arr, const std::string &value)
 {
-  for (int i = 0; i < arr.size(); i++) {
+  for (size_t i = 0; i < arr.size(); i++) {
     if (arr[i] == value) {
       return i;
     }

--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -147,6 +147,8 @@ void sendPIDPacket(const std::string &motor, int32_t pid_target)
   sendCANPacket(p);
 }
 
+// TODO: if this sends the motor packet, should probably be called
+// "sendMotorPacket" instead of "ParseMotorPacket"
 bool ParseMotorPacket(json &message)
 {
   if (Globals::E_STOP) return sendError("Emergency stop is activated");

--- a/src/Networking/motor_interface.cpp
+++ b/src/Networking/motor_interface.cpp
@@ -156,7 +156,7 @@ bool ParseMotorPacket(json &message)
   {
     motor = message["motor"];
   }
-  catch (json::type_error)
+  catch (json::type_error&)
   {
     return sendError("No motor specified");
   }

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -142,16 +142,18 @@ TEST_CASE("Incremental PID", "[BaseStation]")
     p = popCANPacket();
     REQUIRE(GetDeviceSerialNumber(&p) == 1);
     REQUIRE(PacketIsOfID(&p, ID_MOTOR_UNIT_PID_POS_TGT_SET));
-    REQUIRE(GetPIDTargetFromPacket(&p) == start_angle + expected_increment);
+	REQUIRE(GetPIDTargetFromPacket(&p) ==
+			static_cast<unsigned>(start_angle + expected_increment));
 
-    incrementArm();
+	incrementArm();
     REQUIRE(numCANPackets() == 1);
     p = popCANPacket();
     REQUIRE(GetDeviceSerialNumber(&p) == 1);
     REQUIRE(PacketIsOfID(&p, ID_MOTOR_UNIT_PID_POS_TGT_SET));
-    REQUIRE(GetPIDTargetFromPacket(&p) == start_angle + 2 * expected_increment);
+	REQUIRE(GetPIDTargetFromPacket(&p) ==
+			static_cast<unsigned>(start_angle + 2 * expected_increment));
 
-    // Artificially trigger the timeout
+	// Artificially trigger the timeout
     Globals::status_data["arm_base"]["most_recent_command"] = 0;
     incrementArm();
     REQUIRE(numCANPackets() == 0);

--- a/src/Networking/tests.cpp
+++ b/src/Networking/tests.cpp
@@ -142,16 +142,14 @@ TEST_CASE("Incremental PID", "[BaseStation]")
     p = popCANPacket();
     REQUIRE(GetDeviceSerialNumber(&p) == 1);
     REQUIRE(PacketIsOfID(&p, ID_MOTOR_UNIT_PID_POS_TGT_SET));
-	REQUIRE(GetPIDTargetFromPacket(&p) ==
-			static_cast<unsigned>(start_angle + expected_increment));
+	REQUIRE(GetPIDTargetFromPacket(&p) == start_angle + expected_increment);
 
 	incrementArm();
     REQUIRE(numCANPackets() == 1);
     p = popCANPacket();
     REQUIRE(GetDeviceSerialNumber(&p) == 1);
     REQUIRE(PacketIsOfID(&p, ID_MOTOR_UNIT_PID_POS_TGT_SET));
-	REQUIRE(GetPIDTargetFromPacket(&p) ==
-			static_cast<unsigned>(start_angle + 2 * expected_increment));
+	REQUIRE(GetPIDTargetFromPacket(&p) == start_angle + 2 * expected_increment);
 
 	// Artificially trigger the timeout
     Globals::status_data["arm_base"]["most_recent_command"] = 0;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -12,7 +12,7 @@ bool almostEqual(double a, double b, double threshold)
 }
 
 ScopedTimer::ScopedTimer(std::string name)
-	: name(std::move(name)), startTime(std::chrono::high_resolution_clock::now())
+	: startTime(std::chrono::high_resolution_clock::now()), name(std::move(name))
 {
 }
 

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 		{
 			open_success = cap.openFromConfigFile(parser.get<std::string>("c"));
 		}
-		catch (cam::invalid_camera_config c)
+		catch (cam::invalid_camera_config& c)
 		{
 			std::cerr << c.what() << std::endl;
 		}

--- a/src/ar/MarkerSet.cpp
+++ b/src/ar/MarkerSet.cpp
@@ -116,7 +116,7 @@ bool MarkerSet::getMarkerByMappedID(int mapped_id, MarkerPattern &out) const
 		out = markers[this->reverse_mappings.at(mapped_id)];
 		return true;
 	}
-	catch (std::out_of_range)
+	catch (std::out_of_range&)
 	{
 		return false;
 	}

--- a/src/ar/MarkerSet.cpp
+++ b/src/ar/MarkerSet.cpp
@@ -43,7 +43,7 @@ void MarkerSet::init(uint8_t data_region_size, uint8_t border_size, float physic
 	std::vector<MarkerPattern> markerVec;
 	cv::Mat bytesList;
 	dict->bytesList.copyTo(bytesList);
-	for (size_t i = 0; i < bytesList.rows; i++)
+	for (int i = 0; i < bytesList.rows; i++)
 	{
 		cv::Mat row = bytesList.row(i);
 		cv::Mat markerBits = ar_dict::getBitsFromByteList(row, data_region_size);
@@ -101,7 +101,7 @@ bool MarkerSet::isIDMapped(int id) const
 
 bool MarkerSet::getMarkerByID(int id, MarkerPattern &out) const
 {
-	if (id < 0 || id > markers.size())
+	if (id < 0 || static_cast<unsigned>(id) > markers.size())
 	{
 		return false;
 	}

--- a/src/ar/MarkerSetTests.cpp
+++ b/src/ar/MarkerSetTests.cpp
@@ -85,10 +85,10 @@ TEST_CASE("Markers can be retrieved from the MarkerSet")
 	std::vector<MarkerPattern> markers = ms.getMarkers();
 	// marker vector should have the same number of markers as are in the
 	// dictionary
-	CHECK(markers.size() == DICT_4X4_50->bytesList.rows);
+	CHECK(markers.size() == static_cast<unsigned>(DICT_4X4_50->bytesList.rows));
 	SECTION("Markers should be the same as in the dictionary")
 	{
-		for (int i = 0; i < markers.size(); i++)
+		for (size_t i = 0; i < markers.size(); i++)
 		{
 			cv::Mat dict_marker_bits =
 				DICT_4X4_50->getBitsFromByteList(DICT_4X4_50->bytesList.row(i),
@@ -102,7 +102,7 @@ TEST_CASE("Markers can be retrieved from the MarkerSet")
 	}
 	SECTION("Markers can be retrieved by ID")
 	{
-		for (int i = 0; i < markers.size(); i++)
+		for (size_t i = 0; i < markers.size(); i++)
 		{
 			MarkerPattern from_vector = markers[i];
 			MarkerPattern from_set;
@@ -112,11 +112,11 @@ TEST_CASE("Markers can be retrieved from the MarkerSet")
 	}
 	SECTION("Markers can be retrieved by a mapped ID")
 	{
-		int nums[] = {0, 3, 7, 11, 13};
-		for(int i = 0; i < (sizeof(nums) / sizeof(int)); i++){
+		std::array<int, 5> nums{0, 3, 7, 11, 13};
+		for(size_t i = 0; i < nums.size(); i++){
 			ms.addIDMapping(nums[i], i);
 		}
-		for(int i = 0; i < (sizeof(nums) / sizeof(int)); i++){
+		for(size_t i = 0; i < nums.size(); i++){
 			MarkerPattern m;
 			CHECK(ms.getMarkerByMappedID(i, m));
 			CHECK(markers[nums[i]] == m);

--- a/src/ar/Tag.cpp
+++ b/src/ar/Tag.cpp
@@ -4,7 +4,9 @@ namespace AR
 {
 
 Tag::Tag(MarkerPattern marker, cv::Vec3d rvec, cv::Vec3d tvec)
-	: marker_(marker), rvec_(rvec), tvec_(tvec){}
+	: rvec_(rvec), tvec_(tvec), marker_(marker)
+{
+}
 
 cv::Vec3d Tag::getRVec() const
 {

--- a/src/ar/read_landmarks.cpp
+++ b/src/ar/read_landmarks.cpp
@@ -32,7 +32,7 @@ std::thread landmark_thread;
 
 void detectLandmarksLoop(){
 	cv::Mat frame;
-	uint32_t last_frame_no;
+	uint32_t last_frame_no = 0;
 	while(true){
 		if (ar_cam.hasNext(last_frame_no)) {
 			ar_cam.next(frame, last_frame_no);

--- a/src/ar/read_landmarks.cpp
+++ b/src/ar/read_landmarks.cpp
@@ -15,7 +15,7 @@ constexpr size_t NUM_LANDMARKS = 11;
 const point_t ZERO_POINT = {0.0, 0.0, 0.0};
 static points_t make_zero_landmarks(){
 	points_t z;
-	for(int i = 0; i < NUM_LANDMARKS; i++){
+	for(size_t i = 0; i < NUM_LANDMARKS; i++){
 		z.push_back(ZERO_POINT);
 	}
 	return z;
@@ -53,7 +53,7 @@ void detectLandmarksLoop(){
 			// for every possible landmark ID, go through and if the map contains a value for
 			// that ID, add it to the output array (doing appropriate coordinate space
 			// transforms). If not, add a zero point.
-			for (int i = 0; i < NUM_LANDMARKS; i++) {
+			for (size_t i = 0; i < NUM_LANDMARKS; i++) {
 				if (ids_to_camera_coords.find(i) != ids_to_camera_coords.end()) {
 					cv::Vec3d coords = ids_to_camera_coords[i];
 					// if we have extrinsic parameters, multiply coordinates by them to do

--- a/src/ar/read_landmarks.cpp
+++ b/src/ar/read_landmarks.cpp
@@ -13,7 +13,6 @@ namespace AR
 {
 constexpr size_t NUM_LANDMARKS = 11;
 const point_t ZERO_POINT = {0.0, 0.0, 0.0};
-constexpr auto ZERO_DURATION = std::chrono::microseconds(0);
 static points_t make_zero_landmarks(){
 	points_t z;
 	for(int i = 0; i < NUM_LANDMARKS; i++){

--- a/src/camera/Camera.cpp
+++ b/src/camera/Camera.cpp
@@ -9,8 +9,9 @@ using std::string;
 namespace cam
 {
 Camera::Camera()
-	: _capture(std::make_shared<cv::VideoCapture>()), _frame(std::make_shared<cv::Mat>()),
-	  _frame_num(std::make_shared<uint32_t>(0)), _frame_lock(std::make_shared<std::mutex>()),
+	: _frame(std::make_shared<cv::Mat>()), _frame_num(std::make_shared<uint32_t>(0)),
+	  _capture(std::make_shared<cv::VideoCapture>()),
+	  _frame_lock(std::make_shared<std::mutex>()),
 	  _capture_lock(std::make_shared<std::mutex>()), _running(std::make_shared<bool>(false))
 {
 }
@@ -47,10 +48,10 @@ bool Camera::open(string filename, CameraParams intrinsic_params, Mat extrinsic_
 
 Camera::Camera(string filename, string name, string description, CameraParams intrinsic_params,
 			   Mat extrinsic_params)
-	: _name(name), _description(description), _intrinsic_params(intrinsic_params),
-	  _capture(std::make_shared<cv::VideoCapture>(filename)),
-	  _frame(std::make_shared<cv::Mat>()), _frame_num(std::make_shared<uint32_t>(0)),
-	  _frame_lock(std::make_shared<std::mutex>()), _capture_lock(std::make_shared<std::mutex>()),
+	: _frame(std::make_shared<cv::Mat>()), _frame_num(std::make_shared<uint32_t>(0)),
+	  _capture(std::make_shared<cv::VideoCapture>(filename)), _name(name),
+	  _description(description), _frame_lock(std::make_shared<std::mutex>()),
+	  _capture_lock(std::make_shared<std::mutex>()), _intrinsic_params(intrinsic_params),
 	  _running(std::make_shared<bool>(false))
 {
 	init(extrinsic_params);
@@ -58,10 +59,10 @@ Camera::Camera(string filename, string name, string description, CameraParams in
 
 Camera::Camera(int camera_id, string name, string description, CameraParams intrinsic_params,
 			   Mat extrinsic_params)
-	: _name(name), _description(description), _intrinsic_params(intrinsic_params),
-	  _capture(std::make_shared<cv::VideoCapture>(camera_id)),
-	  _frame(std::make_shared<cv::Mat>()), _frame_num(std::make_shared<uint32_t>(0)),
-	  _frame_lock(std::make_shared<std::mutex>()), _capture_lock(std::make_shared<std::mutex>()),
+	: _frame(std::make_shared<cv::Mat>()), _frame_num(std::make_shared<uint32_t>(0)),
+	  _capture(std::make_shared<cv::VideoCapture>(camera_id)), _name(name),
+	  _description(description), _frame_lock(std::make_shared<std::mutex>()),
+	  _capture_lock(std::make_shared<std::mutex>()), _intrinsic_params(intrinsic_params),
 	  _running(std::make_shared<bool>(false))
 {
 	init(extrinsic_params);
@@ -88,11 +89,11 @@ void Camera::init(const Mat &extrinsic_params)
 }
 
 Camera::Camera(const Camera &other)
-	: _running(other._running), _name(other._name), _description(other._description),
-	  _frame(other._frame), _frame_num(other._frame_num), _capture(other._capture),
-	  _extrinsic_params(other._extrinsic_params), _frame_lock(other._frame_lock),
+	: _frame(other._frame), _frame_num(other._frame_num), _capture(other._capture),
+	  _name(other._name), _description(other._description), _frame_lock(other._frame_lock),
 	  _capture_lock(other._capture_lock), _thread(other._thread),
-	  _intrinsic_params(other._intrinsic_params)
+	  _intrinsic_params(other._intrinsic_params), _extrinsic_params(other._extrinsic_params),
+	  _running(other._running)
 {
 }
 

--- a/src/commands/DriveToGateNoCompass.cpp
+++ b/src/commands/DriveToGateNoCompass.cpp
@@ -6,11 +6,12 @@
 #include "Eigen/Dense"
 #include "Eigen/LU"
 
-DriveToGateNoCompass::DriveToGateNoCompass(double driveDist, double angleKP, double vel, double initial_heading)
-	: calibrateDriveDist(driveDist), currOdom(toTransform({0,0,0})), state(State::Done),
-		calibrationPoints(),
-		targetPoint({0,0,0}), angleKP(angleKP), vel(vel), currPose({0,0,0}),
-		checkpointHeading(initial_heading)
+DriveToGateNoCompass::DriveToGateNoCompass(double driveDist, double angleKP, double vel,
+										   double initial_heading)
+	: state(State::Done), checkpointHeading(initial_heading), currOdom(toTransform({0, 0, 0})),
+	  currPose({0, 0, 0}), calibrationPoints(), calibrateDriveDist(driveDist),
+	  targetPoint({0, 0, 0}), angleKP(angleKP), vel(vel)
+
 {
 }
 void DriveToGateNoCompass::reset(transform_t &odom, point_t &target)

--- a/src/commands/DriveToGateNoCompass.h
+++ b/src/commands/DriveToGateNoCompass.h
@@ -1,5 +1,4 @@
-#ifndef ROVER_DRIVETOGATENOCOMPASS_H
-#define ROVER_DRIVETOGATENOCOMPASS_H
+#pragma once
 
 #include "../simulator/utils.h"
 #include "CommandBase.h"
@@ -44,5 +43,3 @@ private:
 	double angleKP;
 	double vel;
 };
-
-#endif // ROVER_DRIVETOGATENOCOMPASS_H

--- a/src/commands/nogps/DriveThroughGate.cpp
+++ b/src/commands/nogps/DriveThroughGate.cpp
@@ -9,8 +9,8 @@
 constexpr double ALIGN_DIST = 2;
 
 DriveThroughGate::DriveThroughGate(double thetaKP, double slowVel, double fastVel)
-	: startOdom(toTransform({0,0,0})), thetaKP(thetaKP), slowVel(slowVel), fastVel(fastVel),
-		state(State::Done), driveTarget(pose_t::Zero())
+	: startOdom(toTransform({0, 0, 0})), driveTarget(pose_t::Zero()), thetaKP(thetaKP),
+	  slowVel(slowVel), fastVel(fastVel), state(State::Done)
 {
 }
 

--- a/src/filters/KalmanFilterBase.h
+++ b/src/filters/KalmanFilterBase.h
@@ -8,8 +8,8 @@ template <int stateDim, int inputDim, int outputDim> class KalmanFilterBase
 {
 public:
 	KalmanFilterBase()
-		: xHat(Eigen::Matrix<double, stateDim, 1>::Zero()),
-		  P(Eigen::Matrix<double, stateDim, stateDim>::Identity() * 1e5)
+		: P(Eigen::Matrix<double, stateDim, stateDim>::Identity() * 1e5),
+		  xHat(Eigen::Matrix<double, stateDim, 1>::Zero())
 	{
 	}
 

--- a/src/lidar/LidarVis.cpp
+++ b/src/lidar/LidarVis.cpp
@@ -25,7 +25,7 @@ void LidarVis::drawPoints(std::vector<PointXY> &pts, cv::Scalar bgr, int pt_radi
 
 void LidarVis::outlinePolygon(std::vector<PointXY> &vertices, cv::Scalar bgr)
 {
-	for (int i = 0; i < vertices.size(); i++)
+	for (size_t i = 0; i < vertices.size(); i++)
 	{
 		cv::Point p1 = worldToCvPoint(vertices[i]);
 		cv::Point p2 = worldToCvPoint(vertices[(i + 1) % vertices.size()]);

--- a/src/lidar/LidarVis.h
+++ b/src/lidar/LidarVis.h
@@ -1,4 +1,4 @@
-#pragma ONCE
+#pragma once
 
 #include <vector>
 

--- a/src/lidar/PointCloudProcessing.cpp
+++ b/src/lidar/PointCloudProcessing.cpp
@@ -86,8 +86,8 @@ std::vector<std::vector<PointXY>> clusterOrderedPoints(std::vector<PointXY> &poi
 {
 	std::vector<std::vector<PointXY>> clusters;
 	std::vector<PointXY> lastCluster;
-	PointXY lastPoint;
 	for (int i = 1; i < points.size(); i++)
+	PointXY lastPoint = points[0];
 	{
 		float diff = distance(points[i].x, points[i].y, points[i - 1].x, points[i - 1].y);
 		if (diff < sep_threshold)

--- a/src/lidar/PointCloudProcessing.cpp
+++ b/src/lidar/PointCloudProcessing.cpp
@@ -53,7 +53,7 @@ std::vector<std::vector<PointXY>> clusterPoints(std::vector<PointXY> &pts, float
 	{
 		int nearest_cluster = -1;
 		float min_dist = std::numeric_limits<float>::infinity();
-		for (int i = 0; i < clusters.size(); i++)
+		for (size_t i = 0; i < clusters.size(); i++)
 		{
 			for (PointXY xyPoint : clusters[i])
 			{
@@ -86,8 +86,8 @@ std::vector<std::vector<PointXY>> clusterOrderedPoints(std::vector<PointXY> &poi
 {
 	std::vector<std::vector<PointXY>> clusters;
 	std::vector<PointXY> lastCluster;
-	for (int i = 1; i < points.size(); i++)
 	PointXY lastPoint = points[0];
+	for (size_t i = 1; i < points.size(); i++)
 	{
 		float diff = distance(points[i].x, points[i].y, points[i - 1].x, points[i - 1].y);
 		if (diff < sep_threshold)
@@ -175,7 +175,7 @@ std::vector<PointXY> convexHull(std::vector<PointXY> &cluster)
 
 	std::vector<PointXY> top_hull;
 	std::vector<PointXY> bot_hull;
-	for (int i = 0; i < cluster.size(); i++)
+	for (size_t i = 0; i < cluster.size(); i++)
 	{
 		while (top_hull.size() >= 2 &&
 			   orientation(top_hull[top_hull.size() - 2], top_hull[top_hull.size() - 1],

--- a/src/lidar/read_hokuyo_lidar.cpp
+++ b/src/lidar/read_hokuyo_lidar.cpp
@@ -34,7 +34,7 @@ void readLidarLoop(){
 		std::vector<Polar2D> polarPts = urg_lidar.getLastFrame();
 		std::vector<point_t> pts(polarPts.size());
 		point_t origin({0,0,1});
-		for (int i = 0; i < polarPts.size(); i++)
+		for (size_t i = 0; i < polarPts.size(); i++)
 		{
 			pts[i] = lidar::polarToCartesian2(polarPts[i]);
 			if ((pts[i] - origin).norm() < LIDAR_MIN_RANGE)

--- a/src/worldmap/GlobalMap.cpp
+++ b/src/worldmap/GlobalMap.cpp
@@ -28,7 +28,7 @@ void GlobalMap::addPoints(const transform_t &robotTrf, const points_t &toAdd, do
 	}
 	transform_t trfInv = robotTrf.inverse();
 	points_t transformed;
-	for (int i = 0; i < toAdd.size(); i += scanStride)
+	for (size_t i = 0; i < toAdd.size(); i += scanStride)
 	{
 		const point_t &point = toAdd[i];
 		if (point(2) != 0)

--- a/src/worldmap/GlobalMap.cpp
+++ b/src/worldmap/GlobalMap.cpp
@@ -3,10 +3,9 @@
 #include <Eigen/LU>
 
 GlobalMap::GlobalMap(double areaSize, int scanStride, int maxIter, double relErrChangeThresh)
-	: tree(areaSize),
-	  scanStride(scanStride),
-	  icp(maxIter, relErrChangeThresh,
-		  std::bind(&GlobalMap::getClosest, this, std::placeholders::_1))
+	: tree(areaSize), icp(maxIter, relErrChangeThresh,
+						  std::bind(&GlobalMap::getClosest, this, std::placeholders::_1)),
+	  scanStride(scanStride)
 {
 }
 

--- a/src/worldmap/QuadTree.cpp
+++ b/src/worldmap/QuadTree.cpp
@@ -226,7 +226,7 @@ point_t QuadTree::getClosestWithin(const point_t &point, double areaSize) const
 		// compute the nearest neighbor in linear time (on a much smaller subset of points)
 		point_t closest = pointsInRange[0];
 		double minDist = (closest - point).topRows<2>().norm();
-		for (int i = 1; i < pointsInRange.size(); i++)
+		for (size_t i = 1; i < pointsInRange.size(); i++)
 		{
 			point_t p = pointsInRange[i];
 			double dist = (p - point).norm();

--- a/src/worldmap/QuadTree.h
+++ b/src/worldmap/QuadTree.h
@@ -125,7 +125,7 @@ private:
 	point_t center;	  // center of bounding box, in word coords
 	double width;	  // size of square area
 	points_t points;  // the points in this node, 0 <= points.size() <= nodeCapacity
-	int nodeCapacity; // number of points stored in each node
+	size_t nodeCapacity; // number of points stored in each node
 	size_t size;	  // number of nodes stored in this or its descendants
 
 	// create children nodes (doesn't check for already existing)

--- a/src/worldmap/TrICP.cpp
+++ b/src/worldmap/TrICP.cpp
@@ -145,7 +145,7 @@ bool TrICP::isDone(int numIter, double mse, double oldMSE) const
 transform_t TrICP::iterate(points_t &sample, int N, double &mse) const
 {
 	PointPair pairs[sample.size()];
-	for (int i = 0; i < sample.size(); i++)
+	for (size_t i = 0; i < sample.size(); i++)
 	{
 		const point_t &point = sample[i];
 		point_t closestPoint = getClosest(point);

--- a/tests/worldmap/GlobalMapTest.cpp
+++ b/tests/worldmap/GlobalMapTest.cpp
@@ -26,7 +26,7 @@ transform_t randTransform(double centerX, double centerY)
 double calculateMSE(const points_t &p1, const points_t &p2)
 {
 	double mse = 0;
-	for (int i = 0; i < p1.size(); i++)
+	for (size_t i = 0; i < p1.size(); i++)
 	{
 		point_t truth = p1[i];
 		point_t p = p2[i];

--- a/tests/worldmap/QuadTreeTest.cpp
+++ b/tests/worldmap/QuadTreeTest.cpp
@@ -24,7 +24,7 @@ TEST_CASE("QuadTree - AddPoints", "[QuadTree]")
 
 	REQUIRE(tree.empty());
 
-	for (int i = 0; i < 50; i++)
+	for (size_t i = 0; i < 50; i++)
 	{
 		const point_t &point = randPoint(100);
 		REQUIRE(tree.getSize() == i);
@@ -42,7 +42,7 @@ TEST_CASE("QuadTree - RemovePoints", "[QuadTree]")
 
 	points_t points;
 
-	for (int i = 0; i < 50; i++)
+	for (size_t i = 0; i < 50; i++)
 	{
 		const point_t &point = randPoint(100);
 		points.push_back(point);
@@ -51,7 +51,7 @@ TEST_CASE("QuadTree - RemovePoints", "[QuadTree]")
 		REQUIRE(tree.getSize() == i + 1);
 	}
 
-	int size = tree.getSize();
+	size_t size = tree.getSize();
 	for (const point_t &point : points)
 	{
 		REQUIRE(tree.getSize() == size);


### PR DESCRIPTION
Turned on a lot of compiler warnings (except for ones about unused variables) and fixed a lot of problems they revealed; most of them appear to be comparisons between signed and unsigned values, which is a minor problem but I think it's best to avoid anything unexpected happening. 

I chose not to enable `-Wconversion` for now since it spits out a lot of errors for Eigen itself; however once I figure out how to stop that we can probably turn that on in a future commit/PR to discover the implicit conversion problems relating to `abs`. 