### PR TITLE
Use higher-res video streaming with Motion 4.2

### DIFF
--- a/rover-config/.motion/motion.conf
+++ b/rover-config/.motion/motion.conf
@@ -9,21 +9,22 @@
 
 stream_localhost off
 stream_motion on
-stream_maxrate 15
-stream_quality 70
-#stream_maxrate 30
-#stream_quality 90
+#stream_maxrate 15
+#stream_quality 70
+stream_maxrate 30
+stream_quality 99
 #
 #minimum_frame_time 1 # handy for collecting camera calibration data, maybe
 
-# This is renamed to `picture_output` in motion 4.2
-# Current Ubuntu packaged version is 4.0
+# This was called `output_pictures` in motion 4.0
+# Current Ubuntu packaged version is 4.0, but we use 4.2 by installing from source
 # check https://motion-project.github.io/motion_config.html
-output_pictures off
+# and https://motion-project.github.io/motion_build.html
+picture_output off
 
 # This is only available in motion 4.2
-# stream_grey on
+#stream_grey on
 
 camera /home/husky/.motion/camera0.conf
 camera /home/husky/.motion/camera1.conf
-camera /home/husky/.motion/camera2.conf
+#camera /home/husky/.motion/camera2.conf


### PR DESCRIPTION
We have to build from source in order to get this on Ubuntu 18.04, but it seems to be worth it (allows higher-resolution streaming and grayscale streaming if we want). It also fixes the bug where we could only stream two cameras at a time!