### PR TITLE
Improve AR tag detection somewhat

### DIFF
--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -144,6 +144,9 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	cap.set(cv::CAP_PROP_FRAME_WIDTH, 640);
+	cap.set(cv::CAP_PROP_FRAME_HEIGHT, 480);
+
 	std::cout << "Opening image window, press Q to quit" << std::endl;
 
 	cv::namedWindow(WINDOW_NAME);
@@ -155,6 +158,7 @@ int main(int argc, char *argv[])
 
 	bool show_grid = false;
 	int grid_spacing = 20;
+	bool show_rejected = false;
 
 	bool loop = true;
 	cv::Size imageSize = PARAMS.getImageSize();
@@ -175,7 +179,8 @@ int main(int argc, char *argv[])
 
 		// Passes frame to the detector class.
 		// Tags will be located and returned.
-		std::vector<AR::Tag> tags = detector.detectTags(frame);
+		std::vector<std::vector<cv::Point2f>> rejected;
+		std::vector<AR::Tag> tags = detector.detectTags(frame, rejected);
 
 		// Draws an outline around the tag and a cross in the center
 		// Projects a cube onto the tag to debug TVec and RVec
@@ -197,6 +202,16 @@ int main(int argc, char *argv[])
 				cv::line(frame, cubePoints[i], cubePoints[i + 4], cv::Scalar(0, 255, 0), 3);
 				cv::line(frame, cubePoints[i + 4], cubePoints[next + 4], cv::Scalar(255, 0, 0),
 						 3);
+			}
+		}
+
+		if(show_rejected){
+			for(const auto& points : rejected){
+				for(size_t i = 0; i < points.size() - 1; i++){
+					const auto& p1 = points[i];
+					const auto& p2 = points[i+1];
+					cv::line(frame, p1, p2, cv::Scalar(255, 0, 255));
+				}
 			}
 		}
 
@@ -227,6 +242,13 @@ int main(int argc, char *argv[])
 			show_grid = false;
 			std::cout << "Grid off" << std::endl;
 			break;
+		case 'r':
+			show_rejected = true;
+			std::cout << "Rejected points on" << std::endl;
+			break;
+		case 'l':
+			show_rejected = false;
+			std::cout << "Rejected points off" << std::endl;
 		default:
 			break;
 		}

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
 		// Passes frame to the detector class.
 		// Tags will be located and returned.
 		std::vector<std::vector<cv::Point2f>> rejected;
-		std::vector<AR::Tag> tags = detector.detectTags(frame, rejected);
+		std::vector<AR::Tag> tags = detector.detectTags(frame, rejected, false);
 
 		// Draws an outline around the tag and a cross in the center
 		// Projects a cube onto the tag to debug TVec and RVec

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -14,25 +14,33 @@
 #include "../camera/CameraParams.h"
 #include "Detector.h"
 
+constexpr int NUM_SKIP = 5;
+
 const std::string WINDOW_NAME = "Image";
 
 const std::string keys =
 	"{h help             |        | Show this help message.}"
 	"{cam_config c       | <none> | The path to a camera configuration file "
 	"defining the camera you would like to use.}"
-	"{cam_override co    | -1     | If present, should be the ID of a camera to open "
+	"{file_override fo   |        | If present, should be the name of a video file to open "
 	"rather than the one defined in the configuration file.}"
+	"{cam_override co    | -1     | If present, should be the ID of a camera to open "
+	"rather than the one defined in the configuration file. NOTE: Will take precedence over "
+	"file_override if both are present.}"
 	"{marker_set m       | urc    | The set of markers to look for. Currently "
 	"only \"urc\" and \"circ\" are supported.}"
 	"{frame_by_frame f   |        | If present, program will go frame-by-frame "
 	"instead of capturing continuously.}";
 
-cam::Camera cap;
+// TODO: come up with a better solution for examining video files
+//cam::Camera cap;
+cv::VideoCapture cap;
 cam::CameraParams PARAMS;
 std::shared_ptr<AR::MarkerSet> MARKER_SET;
 
 std::vector<cv::Point2d> projectCube(float len, cv::Vec3d rvec, cv::Vec3d tvec);
 std::vector<cv::Point2f> projectGrid(cv::Size imageSize, int spacing);
+static inline void noValue(std::string option);
 
 int main(int argc, char *argv[])
 {
@@ -50,7 +58,7 @@ int main(int argc, char *argv[])
 		return EXIT_SUCCESS;
 	}
 
-	if (!parser.has("c"))
+	if (!parser.has("c") || parser.get<std::string>("c").empty())
 	{
 		std::cerr << "Error: camera configuration file is required." << std::endl;
 		parser.printMessage();
@@ -68,6 +76,9 @@ int main(int argc, char *argv[])
 	{
 		MARKER_SET = AR::Markers::URC_MARKERS();
 	}
+	else if (marker_set.empty()){
+		noValue("marker_set");
+	}
 	else
 	{
 		std::cerr << "Unsupported marker set: \"" << marker_set << "\"" << std::endl;
@@ -75,6 +86,8 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	int cam_id = parser.get<int>("co", -1);
+	std::string cam_file = parser.get<std::string>("fo");
 	cv::FileStorage cam_config(parser.get<std::string>("c"), cv::FileStorage::READ);
 	if (!cam_config.isOpened())
 	{
@@ -91,28 +104,38 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 	cam_config[cam::KEY_INTRINSIC_PARAMS] >> PARAMS;
+	// read filename or camera ID, and open camera.
+	if (!cam_config[cam::KEY_FILENAME].empty() && !parser.has("fo"))
+	{
+		cam_file = (std::string)cam_config[cam::KEY_FILENAME];
+	}
+	else if (!cam_config[cam::KEY_CAMERA_ID].empty() && !parser.has("co"))
+	{
+		cam_id = (int)cam_config[cam::KEY_CAMERA_ID];
+	}
+	else if(!parser.has("fo") && !parser.has("co"))
+	{
+		std::cerr << "Error: no file or camera_id was provided in the configuration file or "
+					 "on the command line!"
+				  << std::endl;
+		std::cerr << "Usage:" << std::endl;
+		parser.printMessage();
+		return EXIT_FAILURE;
+	}
 	cam_config.release();
 
 	cv::Mat frame;
 	uint32_t fnum = 0;
 
 	std::cout << "Opening camera..." << std::endl;
-	int cam_override_id = parser.get<int>("co");
 	bool open_success = false;
-	if (cam_override_id > -1)
+	if (cam_id > -1)
 	{
-		open_success = cap.open(cam_override_id, PARAMS);
+		open_success = cap.open(cam_id);
 	}
-	else
+	else if(!cam_file.empty())
 	{
-		try
-		{
-			open_success = cap.openFromConfigFile(parser.get<std::string>("c"));
-		}
-		catch (cam::invalid_camera_config& c)
-		{
-			std::cerr << c.what() << std::endl;
-		}
+		open_success = cap.open(cam_file);
 	}
 
 	if (!open_success)
@@ -139,11 +162,11 @@ int main(int argc, char *argv[])
 	while (loop)
 	{
 		// Grabs frame
-		if (!cap.hasNext(fnum))
+		if (!cap.grab())
 		{
 			continue;
 		}
-		cap.next(frame, fnum);
+		cap.retrieve(frame);
 		if (frame.empty())
 		{
 			std::cerr << "ERROR! Blank frame grabbed" << std::endl;
@@ -182,14 +205,15 @@ int main(int argc, char *argv[])
 			std::vector<cv::Point2f> grid = projectGrid(imageSize, grid_spacing);
 			for (cv::Point2f pt : grid)
 			{
-				cv::Point2f newPt(pt.x * imageSize.width, pt.y * imageSize.height);
+				cv::Point2f newPt(pt.x * (float)imageSize.width,
+								  pt.y * (float)imageSize.height);
 				cv::drawMarker(frame, newPt, cv::Scalar(255, 0, 0), cv::MARKER_CROSS, 10, 1);
 			}
 		}
 
 		cv::imshow(WINDOW_NAME, frame);
 
-		int delay = (frame_by_frame && count % 10 == 0) ? 0 : 1;
+		int delay = (frame_by_frame && count % NUM_SKIP == 0) ? 0 : 1;
 		switch (cv::waitKey(delay))
 		{
 		case 'q':
@@ -206,6 +230,7 @@ int main(int argc, char *argv[])
 		default:
 			break;
 		}
+		count++;
 	}
 
 	return 0;
@@ -232,23 +257,32 @@ std::vector<cv::Point2d> projectCube(float len, cv::Vec3d rvec, cv::Vec3d tvec)
 
 std::vector<cv::Point2f> projectGrid(cv::Size imageSize, int spacing)
 {
-	cv::Point2f center(imageSize.width / 2, imageSize.height / 2);
+	cv::Point2f center((float)imageSize.width / 2.0f, (float)imageSize.height / 2.0f);
 	std::vector<cv::Point2f> grid_points;
 	std::vector<cv::Point2f> projected_points;
+	float xf,yf;
 	for (int x = 0; x < imageSize.width / 2; x += spacing)
 	{
 		for (int y = 0; y < imageSize.height / 2; y += spacing)
 		{
-			grid_points.push_back(cv::Point2f(x, y) + center);
+			xf = (float) x;
+			yf = (float) y;
+			grid_points.push_back(cv::Point2f(xf, yf) + center);
 			if (x != 0 || y != 0)
 			{
-				grid_points.push_back(cv::Point2f(-x, -y) + center);
-				grid_points.push_back(cv::Point2f(-x, y) + center);
-				grid_points.push_back(cv::Point2f(x, -y) + center);
+				grid_points.push_back(cv::Point2f(-xf, -yf) + center);
+				grid_points.push_back(cv::Point2f(-xf, yf) + center);
+				grid_points.push_back(cv::Point2f(xf, -yf) + center);
 			}
 		}
 	}
 	cv::undistortPoints(grid_points, projected_points, PARAMS.getCameraMatrix(),
 						PARAMS.getDistCoeff());
 	return projected_points;
+}
+
+static inline void noValue(std::string option){
+	std::cerr << "Error: No value given for " << option << " option!" << std::endl
+			  << "Please remember to use '=' between flags and values." << std::endl;
+	exit(EXIT_FAILURE);
 }

--- a/src/ar/ARTester.cpp
+++ b/src/ar/ARTester.cpp
@@ -144,8 +144,11 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	cap.set(cv::CAP_PROP_FRAME_WIDTH, 640);
-	cap.set(cv::CAP_PROP_FRAME_HEIGHT, 480);
+	const int w = PARAMS.getImageSize().width;
+	const int h = PARAMS.getImageSize().height;
+	cap.set(cv::CAP_PROP_FRAME_WIDTH, w);
+	cap.set(cv::CAP_PROP_FRAME_HEIGHT, h);
+	std::cout << "Set image dimensions to " << w << " x " << h << std::endl;
 
 	std::cout << "Opening image window, press Q to quit" << std::endl;
 

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -56,4 +56,12 @@ std::vector<Tag> Detector::detectTags(const cv::Mat &input,
 	return tags;
 }
 
+cv::aruco::DetectorParameters Detector::getDetectorParams(){
+	return *detector_params_;
+}
+
+void Detector::setDetectorParams(cv::aruco::DetectorParameters params){
+	*detector_params_ = params;
+}
+
 } // namespace AR

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -21,14 +21,22 @@ Detector::Detector(std::shared_ptr<MarkerSet> marker_set,
 	assert(marker_set != nullptr);
 	assert(detector_params != nullptr);
 	this->detector_params_->markerBorderBits = marker_set->getBorderSize();
+	this->detector_params_->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
 }
 
-std::vector<Tag> Detector::detectTags(const cv::Mat &input)
-{
+std::vector<Tag> Detector::detectTags(const cv::Mat &input){
+	std::vector<std::vector<cv::Point2f>> junk;
+	return detectTags(input, junk);
+}
+
+std::vector<Tag> Detector::detectTags(const cv::Mat &input,
+									  std::vector<std::vector<cv::Point2f>> &rejectedPoints){
 	std::vector<std::vector<cv::Point2f>> corners;
 	std::vector<int> ids;
 	cv::aruco::detectMarkers(input, this->marker_set_->getDict(), corners, ids,
-							 this->detector_params_, cv::noArray(),this->camera_params_.getCameraMatrix(), 
+							 this->detector_params_,
+							 rejectedPoints,
+							 this->camera_params_.getCameraMatrix(),
 							 this->camera_params_.getDistCoeff());
 	int id_count = ids.size();
 

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -37,34 +37,43 @@ bool Detector::empty() const {
 	return (marker_set_ == nullptr || camera_params_.empty() || detector_params_ == nullptr);
 }
 
-std::vector<Tag> Detector::detectTags(const cv::Mat &input){
-	return _detectTagsImpl(input, nullptr);
+std::vector<Tag> Detector::detectTags(const cv::Mat &input, bool undistort){
+	return _detectTagsImpl(input, nullptr, undistort);
 }
 
 std::vector<Tag> Detector::detectTags(const cv::Mat &input,
-									  std::vector<std::vector<cv::Point2f>> &rejectedPoints){
-	return _detectTagsImpl(input, &rejectedPoints);
+									  std::vector<std::vector<cv::Point2f>> &rejectedPoints,
+									  bool undistort) {
+	return _detectTagsImpl(input, &rejectedPoints, undistort);
 }
 
 std::vector<Tag> Detector::_detectTagsImpl(const cv::Mat &input,
-										   std::vector<std::vector<cv::Point2f>>* rejected){
+										   std::vector<std::vector<cv::Point2f>> *rejected,
+										   bool undistort){
 	if(this->empty()){
 		return {};
 	}
 	std::vector<std::vector<cv::Point2f>> corners;
 	std::vector<int> ids;
+	
 	cv::Mat undistorted;
-	cv::remap(input, undistorted, this->map1_, this->map2_, cv::INTER_LINEAR);
+	if (undistort) {
+		cv::remap(input, undistorted, this->map1_, this->map2_, cv::INTER_LINEAR);
+	} else {
+		undistorted = input;
+	}
+	
 	cv::aruco::detectMarkers(undistorted, this->marker_set_->getDict(), corners, ids,
 							 this->detector_params_,
-							 (rejected == nullptr ? cv::noArray() : *rejected),
-							 this->camera_params_.getCameraMatrix(),
-							 this->camera_params_.getDistCoeff());
+							 (rejected == nullptr ? cv::noArray() : *rejected));
+	if(undistort) {
+	}
 
 	std::vector<cv::Vec3d> rvecs, tvecs;
 	cv::aruco::estimatePoseSingleMarkers(corners, this->marker_set_->getPhysicalSize(),
 										 this->camera_params_.getCameraMatrix(),
 										 this->camera_params_.getDistCoeff(), rvecs, tvecs);
+	
 	std::vector<Tag> tags;
 	for(size_t i = 0; i < ids.size(); i++){
 		size_t id = static_cast<size_t>(ids[i]);

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -6,6 +6,8 @@
 
 #include <opencv2/aruco.hpp>
 #include <opencv2/core.hpp>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
 
 #include "../camera/CameraParams.h"
 #include "Tag.h"
@@ -13,41 +15,59 @@
 namespace AR
 {
 
+Detector::Detector(){}
+
 Detector::Detector(std::shared_ptr<MarkerSet> marker_set,
 				   cam::CameraParams camera_params,
 				   cv::Ptr<cv::aruco::DetectorParameters> detector_params)
 	: marker_set_(marker_set), camera_params_(camera_params), detector_params_(detector_params)
 {
-	assert(marker_set != nullptr);
-	assert(detector_params != nullptr);
-	this->detector_params_->markerBorderBits = marker_set->getBorderSize();
-	this->detector_params_->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+	if (!this->empty())
+	{
+		this->detector_params_->markerBorderBits = marker_set->getBorderSize();
+		this->detector_params_->cornerRefinementMethod = cv::aruco::CORNER_REFINE_SUBPIX;
+		cv::initUndistortRectifyMap(camera_params_.getCameraMatrix(),
+									camera_params_.getDistCoeff(), cv::Mat_<double>::eye(3, 3),
+									camera_params_.getCameraMatrix(),
+									camera_params_.getImageSize(), CV_16SC2, map1_, map2_);
+	}
+}
+
+bool Detector::empty() const {
+	return (marker_set_ == nullptr || camera_params_.empty() || detector_params_ == nullptr);
 }
 
 std::vector<Tag> Detector::detectTags(const cv::Mat &input){
-	std::vector<std::vector<cv::Point2f>> junk;
-	return detectTags(input, junk);
+	return _detectTagsImpl(input, nullptr);
 }
 
 std::vector<Tag> Detector::detectTags(const cv::Mat &input,
 									  std::vector<std::vector<cv::Point2f>> &rejectedPoints){
+	return _detectTagsImpl(input, &rejectedPoints);
+}
+
+std::vector<Tag> Detector::_detectTagsImpl(const cv::Mat &input,
+										   std::vector<std::vector<cv::Point2f>>* rejected){
+	if(this->empty()){
+		return {};
+	}
 	std::vector<std::vector<cv::Point2f>> corners;
-	std::vector<int> ids;
+	std::vector<size_t> ids;
+	cv::Mat undistorted;
+	cv::remap(input, undistorted, this->map1_, this->map2_, cv::INTER_LINEAR);
 	cv::aruco::detectMarkers(input, this->marker_set_->getDict(), corners, ids,
 							 this->detector_params_,
-							 rejectedPoints,
+							 (rejected == nullptr ? cv::noArray() : *rejected),
 							 this->camera_params_.getCameraMatrix(),
 							 this->camera_params_.getDistCoeff());
-	int id_count = ids.size();
 
 	std::vector<cv::Vec3d> rvecs, tvecs;
 	cv::aruco::estimatePoseSingleMarkers(corners, this->marker_set_->getPhysicalSize(),
 										 this->camera_params_.getCameraMatrix(),
 										 this->camera_params_.getDistCoeff(), rvecs, tvecs);
-
 	std::vector<Tag> tags;
 	for(size_t i = 0; i < ids.size(); i++){
-		int id = ids[i];
+		size_t id = ids[i];
 		MarkerPattern marker = this->marker_set_->getMarkers()[id];
 		Tag current(marker, rvecs[i], tvecs[i]);
 		tags.push_back(current);

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -28,7 +28,8 @@ std::vector<Tag> Detector::detectTags(const cv::Mat &input)
 	std::vector<std::vector<cv::Point2f>> corners;
 	std::vector<int> ids;
 	cv::aruco::detectMarkers(input, this->marker_set_->getDict(), corners, ids,
-							 this->detector_params_);
+							 this->detector_params_, cv::noArray(),this->camera_params_.getCameraMatrix(), 
+							 this->camera_params_.getDistCoeff());
 	int id_count = ids.size();
 
 	std::vector<cv::Vec3d> rvecs, tvecs;

--- a/src/ar/Detector.cpp
+++ b/src/ar/Detector.cpp
@@ -52,10 +52,10 @@ std::vector<Tag> Detector::_detectTagsImpl(const cv::Mat &input,
 		return {};
 	}
 	std::vector<std::vector<cv::Point2f>> corners;
-	std::vector<size_t> ids;
+	std::vector<int> ids;
 	cv::Mat undistorted;
 	cv::remap(input, undistorted, this->map1_, this->map2_, cv::INTER_LINEAR);
-	cv::aruco::detectMarkers(input, this->marker_set_->getDict(), corners, ids,
+	cv::aruco::detectMarkers(undistorted, this->marker_set_->getDict(), corners, ids,
 							 this->detector_params_,
 							 (rejected == nullptr ? cv::noArray() : *rejected),
 							 this->camera_params_.getCameraMatrix(),
@@ -67,7 +67,7 @@ std::vector<Tag> Detector::_detectTagsImpl(const cv::Mat &input,
 										 this->camera_params_.getDistCoeff(), rvecs, tvecs);
 	std::vector<Tag> tags;
 	for(size_t i = 0; i < ids.size(); i++){
-		size_t id = ids[i];
+		size_t id = static_cast<size_t>(ids[i]);
 		MarkerPattern marker = this->marker_set_->getMarkers()[id];
 		Tag current(marker, rvecs[i], tvecs[i]);
 		tags.push_back(current);

--- a/src/ar/Detector.h
+++ b/src/ar/Detector.h
@@ -23,8 +23,12 @@ private:
 	std::shared_ptr<MarkerSet> marker_set_;
 	cam::CameraParams camera_params_;
 	cv::Ptr<cv::aruco::DetectorParameters> detector_params_;
+	cv::Mat map1_, map2_;
+    std::vector<Tag> _detectTagsImpl(const cv::Mat &input,
+									 std::vector<std::vector<cv::Point2f>>* rejected);
 
 public:
+	Detector();
 	Detector(std::shared_ptr<MarkerSet> marker_set, cam::CameraParams camera_params,
 			 cv::Ptr<cv::aruco::DetectorParameters> detector_params =
 				 cv::aruco::DetectorParameters::create());
@@ -33,6 +37,7 @@ public:
 	std::vector<Tag> detectTags(const cv::Mat &input);
 	cv::aruco::DetectorParameters getDetectorParams();
 	void setDetectorParams(cv::aruco::DetectorParameters params);
+	bool empty() const;
 };
 /** @} */
 

--- a/src/ar/Detector.h
+++ b/src/ar/Detector.h
@@ -31,6 +31,8 @@ public:
 	std::vector<Tag> detectTags(const cv::Mat &input,
 								std::vector<std::vector<cv::Point2f>> &rejected_points);
 	std::vector<Tag> detectTags(const cv::Mat &input);
+	cv::aruco::DetectorParameters getDetectorParams();
+	void setDetectorParams(cv::aruco::DetectorParameters params);
 };
 /** @} */
 

--- a/src/ar/Detector.h
+++ b/src/ar/Detector.h
@@ -24,8 +24,9 @@ private:
 	cam::CameraParams camera_params_;
 	cv::Ptr<cv::aruco::DetectorParameters> detector_params_;
 	cv::Mat map1_, map2_;
-    std::vector<Tag> _detectTagsImpl(const cv::Mat &input,
-									 std::vector<std::vector<cv::Point2f>>* rejected);
+	std::vector<Tag> _detectTagsImpl(const cv::Mat &input,
+									 std::vector<std::vector<cv::Point2f>> *rejected,
+									 bool undistort);
 
 public:
 	Detector();
@@ -33,8 +34,9 @@ public:
 			 cv::Ptr<cv::aruco::DetectorParameters> detector_params =
 				 cv::aruco::DetectorParameters::create());
 	std::vector<Tag> detectTags(const cv::Mat &input,
-								std::vector<std::vector<cv::Point2f>> &rejected_points);
-	std::vector<Tag> detectTags(const cv::Mat &input);
+								std::vector<std::vector<cv::Point2f>> &rejected_points,
+								bool undistort = true);
+	std::vector<Tag> detectTags(const cv::Mat &input, bool undistort = true);
 	cv::aruco::DetectorParameters getDetectorParams();
 	void setDetectorParams(cv::aruco::DetectorParameters params);
 	bool empty() const;

--- a/src/ar/Detector.h
+++ b/src/ar/Detector.h
@@ -28,6 +28,8 @@ public:
 	Detector(std::shared_ptr<MarkerSet> marker_set, cam::CameraParams camera_params,
 			 cv::Ptr<cv::aruco::DetectorParameters> detector_params =
 				 cv::aruco::DetectorParameters::create());
+	std::vector<Tag> detectTags(const cv::Mat &input,
+								std::vector<std::vector<cv::Point2f>> &rejected_points);
 	std::vector<Tag> detectTags(const cv::Mat &input);
 };
 /** @} */

--- a/src/ar/read_landmarks.cpp
+++ b/src/ar/read_landmarks.cpp
@@ -54,8 +54,9 @@ void detectLandmarksLoop(){
 			// that ID, add it to the output array (doing appropriate coordinate space
 			// transforms). If not, add a zero point.
 			for (size_t i = 0; i < NUM_LANDMARKS; i++) {
-				if (ids_to_camera_coords.find(i) != ids_to_camera_coords.end()) {
-					cv::Vec3d coords = ids_to_camera_coords[i];
+				int id = static_cast<int>(i);
+				if (ids_to_camera_coords.find(id) != ids_to_camera_coords.end()) {
+					cv::Vec3d coords = ids_to_camera_coords[id];
 					// if we have extrinsic parameters, multiply coordinates by them to do
 					// appropriate transformation.
 					if (ar_cam.hasExtrinsicParams()) {
@@ -75,7 +76,7 @@ void detectLandmarksLoop(){
 			}
 
 			landmark_lock.lock();
-			for (int i = 0; i < NUM_LANDMARKS; i++) {
+			for (size_t i = 0; i < NUM_LANDMARKS; i++) {
 				// If we already saw this landmark, we don't want to overwrite that with zeros
 				// if we didn't see the landmark on this particular frame. This is because
 				// landmark detection is a bit spotty: even when the rover is not moving,
@@ -97,7 +98,7 @@ void detectLandmarksLoop(){
 
 void zeroCurrent() {
 	current_landmarks.clear();
-	for (int i = 0; i < NUM_LANDMARKS; i++) {
+	for (size_t i = 0; i < NUM_LANDMARKS; i++) {
 		current_landmarks.push_back(ZERO_POINT);
 	}
 }


### PR DESCRIPTION
Improved some parts of the AR detection system; in particular, the `Detector` class now corrects passed-in images for lens distortion which should hopefully improve the ability of the system to approximate the sides of the tags using straight lines. We also made some internal changes that allow the client to change the settings of the underlying ARUco detection code after a `Detector` is constructed. 

We modified the `ARTester` to just use a plain `VideoCapture` object from OpenCV so it could read frames from the input synchronously; the camera system works well for reading live camera feeds, but if asked to stop or used on a video file, it will consume all the available input in its background thread, which makes it bad for the `ARTester`. The change made the tester program pretty messy so we need to refactor that at some point. Maybe make some option for the `Camera` class to run synchronously without using a thread? Definitely a question for after CIRC.