### PR TITLE
Use a vector for urc_targets instead of popping from a queue

### DIFF
--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <memory>
 #include <vector>
-#include <queue>
 #include <future>
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -48,8 +47,8 @@ constexpr std::array<const char *, 7> NAV_STATE_NAMES ({
 class Autonomous : rclcpp::Node
 {
 public:
-	explicit Autonomous(const std::queue<URCLeg> &urc_targets, double controlHz);
-	Autonomous(const std::queue<URCLeg> &urc_targets, double controlHz, const pose_t &startPose);
+	explicit Autonomous(const std::vector<URCLeg> &urc_targets, double controlHz);
+	Autonomous(const std::vector<URCLeg> &urc_targets, double controlHz, const pose_t &startPose);
 	// Returns a pair of floats, in heading, speed
 	// Accepts current heading of the robot as parameter
 	// Gets the target's coordinate
@@ -57,7 +56,8 @@ public:
 	void autonomyIter();
 
 private:
-	std::queue<URCLeg> urc_targets;
+	std::vector<URCLeg> urc_targets;
+  size_t leg_idx; // which of the urc_targets we're currently navigating toward
 	pose_t search_target;
 	// Gate targets are {NAN, NAN, NAN} if unset and {INF, INF, INF} if reached
 	// gate_targets.second(2) is NAN if targets have not been refined with more accurate landmark measurements

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -4,7 +4,6 @@
 #include <csignal>
 #include <unistd.h>
 #include <array>
-#include <queue>
 #include <fstream>
 #include <sstream>
 
@@ -140,8 +139,8 @@ void closeSim(int signum)
     raise(SIGTERM);
 }
 
-std::queue<URCLeg> parseGPSLegs(std::string filepath) {
-	std::queue<URCLeg> urc_legs;
+std::vector<URCLeg> parseGPSLegs(std::string filepath) {
+	std::vector<URCLeg> urc_legs;
 	std::ifstream gps_legs(filepath);
 
 	int left_post_id, right_post_id;
@@ -161,7 +160,7 @@ std::queue<URCLeg> parseGPSLegs(std::string filepath) {
 			point_t leg_map_space = gpsToMeters(lon, lat);
 			URCLeg leg = {left_post_id, right_post_id, leg_map_space};
 			log(LOG_INFO, "Got urc leg at %f %f\n", leg_map_space(0), leg_map_space(1));
-			urc_legs.push(leg);
+			urc_legs.push_back(leg);
 		}
 	}
 	log(LOG_INFO, "Got %d urc legs\n", urc_legs.size());
@@ -173,7 +172,7 @@ std::queue<URCLeg> parseGPSLegs(std::string filepath) {
 		// File does not exist or has no valid legs, use simulation legs as defaults
 		for (int i = 0; i < 7; i++)
 		{
-			urc_legs.push(getLeg(i));
+			urc_legs.push_back(getLeg(i));
 		}
 	}
 
@@ -193,7 +192,7 @@ int rover_loop(int argc, char **argv)
     CANPacket packet;
     // Target locations for autonomous navigation
     // Eventually this will be set by communication from the base station
-    std::queue<URCLeg> urc_legs = parseGPSLegs("../src/gps/simulator_legs.txt");
+    std::vector<URCLeg> urc_legs = parseGPSLegs("../src/gps/simulator_legs.txt");
     Autonomous autonomous(urc_legs, CONTROL_HZ);
     char buffer[MAXLINE];
     struct timeval tp_rover_start;


### PR DESCRIPTION
With a queue, once a target is popped from the queue, it disappears from memory. Using a std::vector seems a bit more flexible to me, in case we want to go back to previous targets or skip ahead to some future target.