### PR TITLE
Three small tweaks to autonomy system

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -49,7 +49,7 @@ static void printLandmarks(points_t& landmarks, int log_level = LOG_DEBUG);
 Autonomous::Autonomous(const std::vector<URCLeg> &_targets, double controlHz)
 	: Node("autonomous"),
 		urc_targets(_targets),
-    leg_idx(5),
+		leg_idx(5),
 		search_target({_targets[0].approx_GPS(0) - PI, _targets[0].approx_GPS(1), -PI / 2}),
 		gate_targets({NAN, NAN, NAN}, {NAN, NAN, NAN}),
 		poseEstimator({0.2, 0.2}, gpsStdDev, Constants::WHEEL_BASE, 1.0 / controlHz),
@@ -72,7 +72,11 @@ Autonomous::Autonomous(const std::vector<URCLeg> &_targets, double controlHz)
 		mapBlindPeriod(15),
 		mapDoesOverlap(false),
 		mapOverlapSampleThreshold(15),
-		pose_graph(0, 10), // for now, we use no landmarks for state estimation
+		// For now, we use no landmarks for state estimation in the pose graph.
+		// We also use a gps_xy_std that's larger than the true std because empirically
+		// that leads to smoother changes in the pose estimate (at least in the simulator),
+		// which are easier for the controller to work with.
+		pose_graph(0, 10, 0.3, 5.0, 0.05),
 		pose_id(0),
 		prev_odom(toTransform({0,0,0})),
 		smoothed_traj({}),

--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -424,17 +424,17 @@ void Autonomous::updateSearchTarget()
 
 plan_t computePlan(transform_t invTransform, point_t goal)
 {
-  // We need to readLidar again from within the planning thread, for thread safety
-  points_t lidar_scan = readLidarScan();
-  auto collide_func = [&](double x, double y, double radius) -> bool {
-      // transform the point to check into map space
-      point_t relPoint = {x, y, 1};
-      point_t p = invTransform * relPoint;
-      transform_t coll_tf = toTransform(relPoint);
-      // TODO implement thread-safe access to `map` if `USE_MAP` is true
-      //if (USE_MAP) return map.hasPointWithin(p, radius); // TODO is this thread-safe?
-      return collides(coll_tf, lidar_scan, radius);
-  };
+	// We need to readLidar again from within the planning thread, for thread safety
+	points_t lidar_scan = readLidarScan();
+	auto collide_func = [&](double x, double y, double radius) -> bool {
+			// transform the point to check into map space
+			point_t relPoint = {x, y, 1};
+			point_t p = invTransform * relPoint;
+			transform_t coll_tf = toTransform(relPoint);
+			// TODO implement thread-safe access to `map` if `USE_MAP` is true
+			//if (USE_MAP) return map.hasPointWithin(p, radius);
+			return collides(coll_tf, lidar_scan, radius);
+	};
 	return getPlan(collide_func, goal, PLANNING_GOAL_REGION_RADIUS);
 }
 

--- a/src/planning/plan.cpp
+++ b/src/planning/plan.cpp
@@ -11,6 +11,8 @@
 #include "../simulator/constants.h"
 #include "../simulator/graphics.h"
 
+const double EPSILON = 1.2; // heuristic weight for weighted A*
+
 using namespace NavSim;
 
 // TODO implement goal orientations?
@@ -90,8 +92,8 @@ class NodeCompare
 public:
   bool operator() (const Node *lhs, const Node *rhs)
   {
-    return (lhs->acc_cost + EPS*(lhs->heuristic_to_goal)) >
-           (rhs->acc_cost + EPS*(rhs->heuristic_to_goal));
+    return (lhs->acc_cost + EPSILON*(lhs->heuristic_to_goal)) >
+           (rhs->acc_cost + EPSILON*(rhs->heuristic_to_goal));
   }
 };
 

--- a/src/planning/plan.cpp
+++ b/src/planning/plan.cpp
@@ -11,7 +11,7 @@
 #include "../simulator/constants.h"
 #include "../simulator/graphics.h"
 
-const double EPSILON = 1.2; // heuristic weight for weighted A*
+constexpr double EPSILON = 1.2; // heuristic weight for weighted A*
 
 using namespace NavSim;
 
@@ -197,4 +197,3 @@ double planCostFromIndex(plan_t &plan, int idx) {
   }
   return cost;
 }
-


### PR DESCRIPTION
1. Fixes a thread safety issue with `computePlan` (we were passing the lidar points by reference, which could be an issue if the outside function returns while `computePlan` is still running).
2. Decreases epsilon for weighted A* (more expensive, but better plans)
3. Update to new `FriendlyGraph` API (and increase the std for GPS data, to try to make the pose estimates less jittery).