### PR TITLE
Move ROS publishing to a separate .cpp file

### DIFF
--- a/src/Autonomous.cpp
+++ b/src/Autonomous.cpp
@@ -462,14 +462,14 @@ void Autonomous::autonomyIter()
 
 	for (transform_t &sm_tf : smoothed_traj) {
 		const pose_t sm_tf_transformed = poseToDraw(toPose(sm_tf, 0.0), pose);
-    rospub::publish(sm_tf_transformed, rospub::PointPub::POSE_GRAPH);
+		rospub::publish(sm_tf_transformed, rospub::PointPub::POSE_GRAPH);
 	}
 
 	transform_t invTransform = toTransform(pose).inverse();
 
 	const points_t landmarks_transformed = transformReadings(smoothed_landmarks,
 			invTransform * VIZ_BASE_TF);
-  rospub::publish_array(landmarks_transformed, rospub::ArrayPub::LANDMARKS);
+	rospub::publish_array(landmarks_transformed, rospub::ArrayPub::LANDMARKS);
 
 	if (nav_state == NavState::DONE && Globals::AUTONOMOUS)
 	{

--- a/src/Autonomous.h
+++ b/src/Autonomous.h
@@ -4,9 +4,6 @@
 #include <memory>
 #include <vector>
 #include <future>
-#include <rclcpp/rclcpp.hpp>
-#include <geometry_msgs/msg/point.hpp>
-#include <geometry_msgs/msg/pose_array.hpp>
 
 #include "Util.h"
 #include "WorldData.h"
@@ -44,7 +41,7 @@ constexpr std::array<const char *, 7> NAV_STATE_NAMES ({
 	"DONE"
 });
 
-class Autonomous : rclcpp::Node
+class Autonomous
 {
 public:
 	explicit Autonomous(const std::vector<URCLeg> &urc_targets, double controlHz);
@@ -89,14 +86,6 @@ private:
 	trajectory_t smoothed_traj; // cached solution to pose graph optimization (robot trajectory)
 	points_t smoothed_landmarks; // cached solution to pose graph optimization (AR tags)
 
-	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr plan_pub;
-	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr curr_pose_pub;
-	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr drive_target_pub;
-	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr plan_target_pub;
-	rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr pose_graph_pub;
-	rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr lidar_pub;
-	rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr landmarks_pub;
-
 	void setNavState(NavState s);
 	void update_nav_state(const pose_t &pose, const pose_t &plan_target);
 	pose_t choose_plan_target(const pose_t &pose);
@@ -111,9 +100,5 @@ private:
 	double getLinearVel(const pose_t &drive_target, const pose_t &pose, double thetaErr) const;
 	double getThetaVel(const pose_t &drive_target, const pose_t &pose, double &thetaErr) const;
 	pose_t poseToDraw(const pose_t &pose, const pose_t &current_pose) const;
-	void publish(Eigen::Vector3d pose,
-			rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr &publisher) const;
-	void publish_array(const points_t &points,
-			rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr &publisher) const;
 
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(rover_common SHARED
   CommandLineOptions.cpp
   Globals.cpp
   log.cpp
+  rospub.cpp
   Networking/ParseBaseStation.cpp
   Networking/IK.cpp
   Networking/ParseCAN.cpp

--- a/src/Rover.cpp
+++ b/src/Rover.cpp
@@ -10,6 +10,7 @@
 #include "CommandLineOptions.h"
 #include "Globals.h"
 #include "log.h"
+#include "rospub.h"
 #include "Rover.h"
 #include "Util.h"
 #include "Networking/NetworkConstants.h"
@@ -135,7 +136,7 @@ void InitializeRover(uint8_t arm_mode, bool zero_encoders)
 
 void closeSim(int signum)
 {
-    rclcpp::shutdown();
+    rospub::shutdown();
     raise(SIGTERM);
 }
 
@@ -184,7 +185,7 @@ int rover_loop(int argc, char **argv)
     LOG_LEVEL = LOG_INFO;
     Globals::AUTONOMOUS = false;
     world_interface_init();
-    rclcpp::init(0, nullptr);
+    rospub::init();
     // Ctrl+C doesn't stop the simulation without this line
     signal(SIGINT, closeSim);
     Globals::opts = ParseCommandLineOptions(argc, argv);

--- a/src/rospub.cpp
+++ b/src/rospub.cpp
@@ -1,0 +1,81 @@
+
+#include "rospub.h"
+
+#include <map>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
+
+namespace rospub {
+
+constexpr const char * ROVER_FRAME = "rover";
+
+std::map<PointPub, std::string> point_pub_names = {
+  {PointPub::PLAN_VIZ, "plan_viz"},
+  {PointPub::CURRENT_POSE, "current_pose"},
+  {PointPub::DRIVE_TARGET, "drive_target"},
+  {PointPub::PLAN_TARGET, "plan_target"},
+  {PointPub::POSE_GRAPH, "pose_graph"}
+};
+
+std::map<ArrayPub, std::string> array_pub_names = {
+  {ArrayPub::LIDAR_SCAN, "lidar_scan"},
+  {ArrayPub::LANDMARKS, "landmarks"}
+};
+
+rclcpp::Node *node;
+
+std::map<PointPub, rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr> point_pubs;
+std::map<ArrayPub, rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr> array_pubs;
+
+void init() {
+  rclcpp::init(0, nullptr);
+  node = new rclcpp::Node("husky_pub");
+
+  for (int idx = PointPub::PLAN_VIZ; idx <= PointPub::POSE_GRAPH; idx++)
+  {
+    PointPub idx_ = static_cast<PointPub>(idx);
+    point_pubs[idx_] = node->create_publisher<geometry_msgs::msg::Point>(
+        point_pub_names[idx_], 100);
+  }
+
+  for (int idx = ArrayPub::LIDAR_SCAN; idx <= ArrayPub::LANDMARKS; idx++)
+  {
+    ArrayPub idx_ = static_cast<ArrayPub>(idx);
+    array_pubs[idx_] = node->create_publisher<geometry_msgs::msg::PoseArray>(
+        array_pub_names[idx_], 100);
+  }
+}
+
+void shutdown() {
+  rclcpp::shutdown();
+  free(node);
+}
+
+void publish(const pose_t &pose, PointPub topic)
+{
+	auto message = geometry_msgs::msg::Point();
+	message.x = pose(0);
+	message.y = pose(1);
+	message.z = pose(2);
+  point_pubs[topic]->publish(message);
+}
+
+void publish_array(const points_t &points, ArrayPub topic)
+{
+	auto message = geometry_msgs::msg::PoseArray();
+	message.header.frame_id = ROVER_FRAME; // technically this is in the window frame actually
+	// but we'll figure out our transform situation later
+	for (point_t l : points) {
+		auto p = geometry_msgs::msg::Pose();
+		p.position.x = l(0);
+		p.position.y = l(1);
+		p.position.z = l(2);
+		message.poses.push_back(p);
+	}
+	array_pubs[topic]->publish(message);
+}
+
+} // namespace rospub

--- a/src/rospub.cpp
+++ b/src/rospub.cpp
@@ -13,16 +13,16 @@ namespace rospub {
 constexpr const char * ROVER_FRAME = "rover";
 
 std::map<PointPub, std::string> point_pub_names = {
-  {PointPub::PLAN_VIZ, "plan_viz"},
-  {PointPub::CURRENT_POSE, "current_pose"},
-  {PointPub::DRIVE_TARGET, "drive_target"},
-  {PointPub::PLAN_TARGET, "plan_target"},
-  {PointPub::POSE_GRAPH, "pose_graph"}
+	{PointPub::PLAN_VIZ, "plan_viz"},
+	{PointPub::CURRENT_POSE, "current_pose"},
+	{PointPub::DRIVE_TARGET, "drive_target"},
+	{PointPub::PLAN_TARGET, "plan_target"},
+	{PointPub::POSE_GRAPH, "pose_graph"}
 };
 
 std::map<ArrayPub, std::string> array_pub_names = {
-  {ArrayPub::LIDAR_SCAN, "lidar_scan"},
-  {ArrayPub::LANDMARKS, "landmarks"}
+	{ArrayPub::LIDAR_SCAN, "lidar_scan"},
+	{ArrayPub::LANDMARKS, "landmarks"}
 };
 
 rclcpp::Node *node;
@@ -31,27 +31,27 @@ std::map<PointPub, rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr> poin
 std::map<ArrayPub, rclcpp::Publisher<geometry_msgs::msg::PoseArray>::SharedPtr> array_pubs;
 
 void init() {
-  rclcpp::init(0, nullptr);
-  node = new rclcpp::Node("husky_pub");
+	rclcpp::init(0, nullptr);
+	node = new rclcpp::Node("husky_pub");
 
-  for (int idx = PointPub::PLAN_VIZ; idx <= PointPub::POSE_GRAPH; idx++)
-  {
-    PointPub idx_ = static_cast<PointPub>(idx);
-    point_pubs[idx_] = node->create_publisher<geometry_msgs::msg::Point>(
-        point_pub_names[idx_], 100);
-  }
+	for (int idx = PointPub::PLAN_VIZ; idx <= PointPub::POSE_GRAPH; idx++)
+	{
+		PointPub idx_ = static_cast<PointPub>(idx);
+		point_pubs[idx_] = node->create_publisher<geometry_msgs::msg::Point>(
+				point_pub_names[idx_], 100);
+	}
 
-  for (int idx = ArrayPub::LIDAR_SCAN; idx <= ArrayPub::LANDMARKS; idx++)
-  {
-    ArrayPub idx_ = static_cast<ArrayPub>(idx);
-    array_pubs[idx_] = node->create_publisher<geometry_msgs::msg::PoseArray>(
-        array_pub_names[idx_], 100);
-  }
+	for (int idx = ArrayPub::LIDAR_SCAN; idx <= ArrayPub::LANDMARKS; idx++)
+	{
+		ArrayPub idx_ = static_cast<ArrayPub>(idx);
+		array_pubs[idx_] = node->create_publisher<geometry_msgs::msg::PoseArray>(
+				array_pub_names[idx_], 100);
+	}
 }
 
 void shutdown() {
-  rclcpp::shutdown();
-  free(node);
+	rclcpp::shutdown();
+	free(node);
 }
 
 void publish(const pose_t &pose, PointPub topic)
@@ -60,7 +60,7 @@ void publish(const pose_t &pose, PointPub topic)
 	message.x = pose(0);
 	message.y = pose(1);
 	message.z = pose(2);
-  point_pubs[topic]->publish(message);
+	point_pubs[topic]->publish(message);
 }
 
 void publish_array(const points_t &points, ArrayPub topic)

--- a/src/rospub.h
+++ b/src/rospub.h
@@ -5,22 +5,22 @@
 
 namespace rospub {
 
-  enum PointPub {
-    PLAN_VIZ,
-    CURRENT_POSE,
-    DRIVE_TARGET,
-    PLAN_TARGET,
-    POSE_GRAPH
-  };
+	enum PointPub {
+		PLAN_VIZ,
+		CURRENT_POSE,
+		DRIVE_TARGET,
+		PLAN_TARGET,
+		POSE_GRAPH
+	};
 
-  enum ArrayPub {
-    LIDAR_SCAN,
-    LANDMARKS
-  };
+	enum ArrayPub {
+		LIDAR_SCAN,
+		LANDMARKS
+	};
 
-  void init();
-  void shutdown();
-  void publish(const pose_t &pose, PointPub topic); // Also can be used for point_t
-  void publish_array(const points_t &points, ArrayPub topic);
+	void init();
+	void shutdown();
+	void publish(const pose_t &pose, PointPub topic); // Also can be used for point_t
+	void publish_array(const points_t &points, ArrayPub topic);
 
 }

--- a/src/rospub.h
+++ b/src/rospub.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+#include "simulator/utils.h"
+
+namespace rospub {
+
+  enum PointPub {
+    PLAN_VIZ,
+    CURRENT_POSE,
+    DRIVE_TARGET,
+    PLAN_TARGET,
+    POSE_GRAPH
+  };
+
+  enum ArrayPub {
+    LIDAR_SCAN,
+    LANDMARKS
+  };
+
+  void init();
+  void shutdown();
+  void publish(const pose_t &pose, PointPub topic); // Also can be used for point_t
+  void publish_array(const points_t &points, ArrayPub topic);
+
+}


### PR DESCRIPTION
I thought that including rclcpp.h was slowing down compilation for
Rover.cpp and Autonomous.cpp, so I decided to move that into a separate
file rospub.cpp so that we don't need to recompile the publishing logic
every time we e.g. add a print statement to Autonomous.cpp for
debugging.

In the end, I'm not sure this actually improved compile times by much,
but I think it's a nice refactor regardless. Anything that shortens the
Autonomous.cpp file is a good thing, IMO....