### PR TITLE
Limit switch implementation

### DIFF
--- a/src/CAN/CANMotor.cpp
+++ b/src/CAN/CANMotor.cpp
@@ -161,6 +161,12 @@ void pullMotorPosition(devicegroup_t group, deviceserial_t serial) {
 	pullDeviceTelemetry(std::make_pair(group, serial), telemtype_t::angle);
 }
 
+DataPoint<int32_t> getMotorLimits(deviceserial_t serial) {
+	return getDeviceTelemetry(std::make_pair(devicegroup_t::motor, serial),
+							  telemtype_t::limit_switch);
+}
+
+
 callbackid_t addLimitSwitchCallback(
 	devicegroup_t group, deviceserial_t serial,
 	const std::function<void(devicegroup_t group, deviceserial_t serial,

--- a/src/CAN/CANMotor.h
+++ b/src/CAN/CANMotor.h
@@ -180,6 +180,14 @@ robot::types::DataPoint<int32_t> getMotorPosition(devicegroup_t group, deviceser
 void pullMotorPosition(devicegroup_t group, deviceserial_t serial);
 
 /**
+ * @brief Get status of limit switch.
+ * 
+ * @param serial The CAN serial number of the motor board.
+ */
+robot::types::DataPoint<int32_t> getMotorLimits(deviceserial_t serial);
+
+
+/**
  * @brief Add a callback that is invoked when the limit switch is triggered for a motor board.
  *
  * The event is only triggered when the limit switch is clicked, not released.

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -138,6 +138,15 @@ constexpr auto JOINT_MOTOR_MAP = frozen::make_unordered_map<jointid_t, motorid_t
 	 {jointid_t::drillActuator, motorid_t::drillActuator},
 	 {jointid_t::drillMotor, motorid_t::drillMotor}});
 
+constexpr auto MOTOR_JOINT_MAP = frozen::make_unordered_map<motorid_t, jointid_t>(
+	{{motorid_t::armBase, jointid_t::armBase},
+	 {motorid_t::shoulder, jointid_t::shoulder},
+	 {motorid_t::elbow, jointid_t::elbow},
+	 {motorid_t::forearm, jointid_t::forearm},
+	 {motorid_t::hand, jointid_t::hand},
+	 {motorid_t::drillActuator, jointid_t::drillActuator},
+	 {motorid_t::drillMotor, jointid_t::drillMotor}});
+
 // Arm inverse kinematics
 namespace arm {
 /**

--- a/src/LimitCalib.cpp
+++ b/src/LimitCalib.cpp
@@ -35,6 +35,7 @@ void cleanup(int signum) {
 int main() {
 	// init motors.
 	robot::world_interface_init(std::nullopt, true);
+	std::cout << "start limit switch calibration" << std::endl;
 
 	signal(SIGINT, cleanup);
 

--- a/src/control_interface.cpp
+++ b/src/control_interface.cpp
@@ -79,10 +79,37 @@ void setJointPower(robot::types::jointid_t joint, double power) {
 		power /= std::abs(power);
 	}
 
-	// store power value
-	setJointPowerValue(joint, power);
-	// set motor power
-	setJointMotorPower(joint, power);
+	robot::types::motorid_t motorID = Constants::JOINT_MOTOR_MAP.at(joint);
+
+	bool limSwitchTriggered = getMotorLimStatus(motorID);
+
+	std::cout << "mission control goes through here" << std::endl;
+	if (limSwitchTriggered) {
+		// Check what direction it is able to go in the event of hitting that limit switch
+		// For time being direction that it can still go will be hardcoded to avoid extra 
+		// complexity for a system that might only have like 4 limit switches
+		// THIS WILL BE CHANGED TO SWITCH STATEMENT LATER TO MAKE IT CLEANER
+		if (motorID == robot::types::motorid_t::shoulder) {
+			if (power > 0.0) {
+				// store power value
+				setJointPowerValue(joint, power);
+				// set motor power
+				setJointMotorPower(joint, power);
+			}
+			else {
+				LOG_F(WARNING, "Limit switch has been triggered! Preventing movement of motor");
+			}
+		}
+		else {
+			LOG_F(WARNING, "Motor does not have proper power supply handling for case where limit switch has been triggered!");
+		}
+	}
+	else {
+		// store power value
+		setJointPowerValue(joint, power);
+		// set motor power
+		setJointMotorPower(joint, power);
+	}
 }
 
 void setJointPos(robot::types::jointid_t joint, int32_t targetPos) {

--- a/src/utils/scheduler.h
+++ b/src/utils/scheduler.h
@@ -301,6 +301,8 @@ private:
 	}
 };
 
+
+
 /**
  * @brief An abstract class that can be overridden to run long-running tasks and encapsulate
  * task-related data.

--- a/src/world_interface/data.h
+++ b/src/world_interface/data.h
@@ -107,6 +107,12 @@ constexpr auto name_to_motorid = frozen::make_unordered_map<frozen::string, moto
 	 {"elbow", motorid_t::elbow},
 	 {"forearm", motorid_t::forearm}});
 
+constexpr auto motorid_to_name = frozen::make_unordered_map<motorid_t, frozen::string>(
+	{{motorid_t::armBase, "armBase"},
+	 {motorid_t::shoulder, "shoulder"},
+	 {motorid_t::elbow, "elbow"},
+	 {motorid_t::forearm, "forearm"}});
+
 constexpr auto name_to_jointid = frozen::make_unordered_map<frozen::string, jointid_t>(
 	{{"armBase", jointid_t::armBase},
 	 {"shoulder", jointid_t::shoulder},

--- a/src/world_interface/data.h
+++ b/src/world_interface/data.h
@@ -101,6 +101,12 @@ constexpr auto all_jointid_t = frozen::make_unordered_set<jointid_t>(
 	 jointid_t::wristRoll, jointid_t::wristPitch, jointid_t::hand, jointid_t::handActuator, jointid_t::ikForward,
    jointid_t::ikUp, jointid_t::fourBarLinkage, jointid_t::drillActuator, jointid_t::drillMotor});
 
+constexpr auto name_to_motorid = frozen::make_unordered_map<frozen::string, motorid_t>(
+	{{"armBase", motorid_t::armBase},
+	 {"shoulder", motorid_t::shoulder},
+	 {"elbow", motorid_t::elbow},
+	 {"forearm", motorid_t::forearm}});
+
 constexpr auto name_to_jointid = frozen::make_unordered_map<frozen::string, jointid_t>(
 	{{"armBase", jointid_t::armBase},
 	 {"shoulder", jointid_t::shoulder},

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -10,10 +10,15 @@
 #include "motor/can_motor.h"
 #include "real_world_constants.h"
 #include "world_interface.h"
+#include "../Globals.h"
+#include "../control_interface.h"
+#include "../utils/scheduler.h"							// For Watchdog
 
+#include <chrono>										// For ms and time
 #include <future>
 #include <iostream>
 #include <loguru.hpp>
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -34,6 +39,14 @@ std::unordered_map<robot::types::motorid_t, std::shared_ptr<robot::base_motor>> 
 namespace {
 kinematics::DiffDriveKinematics drive_kinematics(Constants::EFF_WHEEL_BASE);
 bool is_emergency_stopped = false;
+
+/**
+ * @brief Limit switch handler. Called when limit switch status is updated
+ *
+ * @param motor The motor to set the target position of.
+ * @param limitSwitchData new data regarding the limit switch represented as a data point
+ */
+void limitSwtichCB(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData);
 
 void addMotorMapping(motorid_t motor, bool hasPosSensor) {
   double posScale = 0;
@@ -65,6 +78,21 @@ std::unordered_map<CameraID, std::weak_ptr<cam::Camera>> cameraMap;
 
 callbackid_t nextCallbackID = 0;
 std::unordered_map<callbackid_t, can::callbackid_t> callbackIDMap;
+
+// Variable 
+std::shared_mutex limitSwitchMapMutex;
+
+const std::chrono::milliseconds LIMIT_SWITCH_TIMEOUT = std::chrono::milliseconds(1000);
+
+// Map correlating limit switch to it's status where false is not triggered
+// and true is triggered. The second value of the pair corresponds to the most
+// timestamp that this limit switch has been triggered at
+std::map<motorid_t, std::pair<bool, std::chrono::time_point<std::chrono::steady_clock>>> limSwitchMap;
+
+// Watch doing reference. Whenever this watchdog timer goes off regardless for what limit
+// switch we will check whether any of the limit switches have timed out from the limit switch
+// timer map
+std::unique_ptr<util::Watchdog<>> watchDogPointer;
 
 void initMotors() {
 	for (const auto& it : motorSerialIDMap) {
@@ -107,6 +135,10 @@ void initMotors() {
 		pidcoef_t pid = motorPIDMap.at(motor);
 		can::motor::setMotorPIDConstants(group, serial, pid.kP, pid.kI, pid.kD);
 	}
+
+	// initialize limit switches
+	robot::addLimitSwitchCallback(robot::types::motorid_t::elbow, limitSwtichCB);
+	robot::addLimitSwitchCallback(robot::types::motorid_t::shoulder, limitSwtichCB);
 }
 
 std::shared_ptr<cam::Camera> openCamera_(CameraID camID) {
@@ -288,6 +320,10 @@ void setMotorPos(robot::types::motorid_t motor, int32_t targetPos) {
 	motor_ptr->setMotorPos(targetPos);
 }
 
+bool getMotorLimStatus(robot::types::motorid_t motor) {
+	return limSwitchMap.at(motor).first;
+}
+
 types::DataPoint<int32_t> getMotorPos(robot::types::motorid_t motor) {
 	std::shared_ptr<robot::base_motor> motor_ptr = getMotor(motor);
 	return motor_ptr->getMotorPos();
@@ -337,6 +373,66 @@ callbackid_t addLimitSwitchCallback(
 
 void removeLimitSwitchCallback(callbackid_t id) {
 	return can::motor::removeLimitSwitchCallback(callbackIDMap.at(id));
+}
+
+void limitSwitchPoll() {
+	// Check whether any of the limit switches have timed out and reset their status
+	// You must then update the mission control that the limit switch has timed out
+	// and has been reset
+	int limitSwitchesNotReset = 0;
+	for (const auto& [key, value] : limSwitchMap) {
+		
+		// Check if the limit switch is currently being marked as active, then check if
+		// timeout
+		if (value.first) {
+			if (std::chrono::steady_clock::now() - value.second >= LIMIT_SWITCH_TIMEOUT) {
+				limSwitchMap[key].first = false;
+					json msg = {{"type", "LimitUpdate"},
+								{"motor", motorid_to_name.at(key).data()},
+								{"status", false}};	
+
+				Globals::websocketServer.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
+			}
+			else {
+				limitSwitchesNotReset++;
+			}
+		}
+	}
+
+	// No limit switch activity delete thread and object to use less resources
+	if (limitSwitchesNotReset == 0 && watchDogPointer != nullptr) {
+		watchDogPointer = nullptr;
+	}
+}
+
+void limitSwtichCB(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) {
+	if (!motorid_to_name.count(motor)) {
+		LOG_F(ERROR, "ERROR: Tried to handle limit switch from motor that does not exist!");
+		return;
+	}
+
+	std::unique_lock guard(limitSwitchMapMutex);		
+	limSwitchMap[motor].first = true;
+	limSwitchMap[motor].second = std::chrono::steady_clock::now();
+
+	jointid_t jointID = Constants::MOTOR_JOINT_MAP.at(motor);
+
+	// set both joint and motor power to 0
+	robot::setJointPower(jointID, 0.0);
+	robot::setMotorPower(motor, 0.0);
+
+	// Create a general watchdog reference, fires every 0.1 seconds (Very fast poll to handle multiple limit
+	// at once)
+	if (watchDogPointer == nullptr) {
+		watchDogPointer = std::make_unique<util::Watchdog<std::chrono::_V2::steady_clock>>
+			("LimitSwitch WatchDog timer", std::chrono::milliseconds(100), limitSwitchPoll, true);
+	}
+
+	json msg = {{"type", "LimitUpdate"},
+				{"motor", motorid_to_name.at(motor).data()},
+				{"status", true}};	
+
+	Globals::websocketServer.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
 }
 
 } // namespace robot

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -380,13 +380,13 @@ void limitSwitchPoll() {
 	// You must then update the mission control that the limit switch has timed out
 	// and has been reset
 	int limitSwitchesNotReset = 0;
+	std::unique_lock guard(limitSwitchMapMutex);
 	for (const auto& [key, value] : limSwitchMap) {
 		
 		// Check if the limit switch is currently being marked as active, then check if
 		// timeout
 		if (value.first) {
 			if (std::chrono::steady_clock::now() - value.second >= LIMIT_SWITCH_TIMEOUT) {
-				std::unique_lock guard(limitSwitchMapMutex);
 				limSwitchMap[key].first = false;
 					json msg = {{"type", "LimitUpdate"},
 								{"motor", motorid_to_name.at(key).data()},

--- a/src/world_interface/real_world_interface.cpp
+++ b/src/world_interface/real_world_interface.cpp
@@ -386,6 +386,7 @@ void limitSwitchPoll() {
 		// timeout
 		if (value.first) {
 			if (std::chrono::steady_clock::now() - value.second >= LIMIT_SWITCH_TIMEOUT) {
+				std::unique_lock guard(limitSwitchMapMutex);
 				limSwitchMap[key].first = false;
 					json msg = {{"type", "LimitUpdate"},
 								{"motor", motorid_to_name.at(key).data()},
@@ -411,7 +412,7 @@ void limitSwtichCB(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) 
 		return;
 	}
 
-	std::unique_lock guard(limitSwitchMapMutex);		
+	std::unique_lock guard(limitSwitchMapMutex);
 	limSwitchMap[motor].first = true;
 	limSwitchMap[motor].second = std::chrono::steady_clock::now();
 

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -173,7 +173,7 @@ void handleIMU(json msg) {
 	lastOrientation = q;
 }
 
-void callBackTest() {
+void limitSwitchPoll() {
 	// Check whether any of the limit switches have timed out and reset their status
 	// You must then update the mission control that the limit switch has timed out
 	// and has been reset
@@ -223,7 +223,7 @@ void handleLim(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) {
 	// at once)
 	if (watchDogPointer == nullptr) {
 		watchDogPointer = std::make_unique<util::Watchdog<std::chrono::_V2::steady_clock>>
-			("LimitSwitch WatchDog timer", std::chrono::milliseconds(100), callBackTest, true);
+			("LimitSwitch WatchDog timer", std::chrono::milliseconds(100), limitSwitchPoll, true);
 	}
 
 	json msg = {{"type", "LimitUpdate"},

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -11,6 +11,8 @@
 #include "world_interface.h"
 #include "../Globals.h"
 #include "../utils/scheduler.h"
+#include "../control_interface.h"
+
 
 #include <chrono>										// For ms and time
 #include <atomic>
@@ -210,6 +212,12 @@ void handleLim(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) {
 	std::unique_lock guard(limitSwitchMapMutex);		
 	limSwitchMap[motor].first = true;
 	limSwitchMap[motor].second = std::chrono::steady_clock::now();
+
+	jointid_t jointID = Constants::MOTOR_JOINT_MAP.at(motor);
+
+	// set both joint and motor power to 0
+	robot::setJointPower(jointID, 0.0);
+	robot::setMotorPower(motor, 0.0);
 
 	// Create a general watchdog reference, fires every 0.1 seconds (Very fast poll to handle multiple limit
 	// at once)
@@ -466,6 +474,10 @@ void setMotorPower(motorid_t motor, double normalizedPWM) {
 void setMotorPos(motorid_t motor, int32_t targetPos) {
 	std::shared_ptr<robot::base_motor> motor_ptr = getMotor(motor);
 	motor_ptr->setMotorPos(targetPos);
+}
+
+bool getMotorLimStatus(robot::types::motorid_t motor) {
+	return limSwitchMap.at(motor).first;
 }
 
 DataPoint<int32_t> getMotorPos(motorid_t motor) {

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -9,6 +9,7 @@
 #include "../utils/transform.h"
 #include "motor/sim_motor.h"
 #include "world_interface.h"
+#include "../Globals.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -150,7 +151,15 @@ void handleIMU(json msg) {
 }
 
 void handleLim(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) {
-	std::cout << "test" << std::endl;
+	if (!motorid_to_name.count(motor)) {
+		LOG_F(ERROR, "ERROR: Tried to handle limit switch from motor that does not exist!");
+		return;
+	}
+	json msg = {{"type", "LimitAlert"},
+				{"motor", motorid_to_name.at(motor).data()}};
+	std::cout << motorid_to_name.at(motor).data() << std::endl;
+
+	Globals::websocketServer.sendJSON(Constants::MC_PROTOCOL_NAME, msg);
 }
 
 void handleCamFrame(json msg) {

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -170,20 +170,21 @@ void handleMotorStatus(json msg) {
 }
 
 void handleLimitSwitch(json msg) {
-	std::string motorName = msg["motor"];
-	uint8_t data;
-	std::string limit = msg["limit"];
-	if (limit == "maximum") {
-		data = 1 << LIMIT_SWITCH_LIM_MAX_IDX;
-	} else if (limit == "minimum") {
-		data = 1 << LIMIT_SWITCH_LIM_MIN_IDX;
-	}
-	DataPoint<LimitSwitchData> lsData(data);
+	std::cout << "limit" << std::endl; 
+	// std::string motorName = msg["motor"];
+	// uint8_t data;
+	// std::string limit = msg["limit"];
+	// if (limit == "maximum") {
+	// 	data = 1 << LIMIT_SWITCH_LIM_MAX_IDX;
+	// } else if (limit == "minimum") {
+	// 	data = 1 << LIMIT_SWITCH_LIM_MIN_IDX;
+	// }
+	// DataPoint<LimitSwitchData> lsData(data);
 
-	std::lock_guard lock(limitSwitchCallbackMapMutex);
-	for (const auto& entry : limitSwitchCallbackMap.at(motorName)) {
-		entry.second(lsData);
-	}
+	// std::lock_guard lock(limitSwitchCallbackMapMutex);
+	// for (const auto& entry : limitSwitchCallbackMap.at(motorName)) {
+	// 	entry.second(lsData);
+	// }
 }
 
 void handleTruePose(json msg) {
@@ -220,7 +221,7 @@ void initSimServer(net::websocket::SingleClientWSServer& ws) {
 	protocol->addMessageHandler("simGpsPositionReport", handleGPS);
 	protocol->addMessageHandler("simCameraStreamReport", handleCamFrame);
 	protocol->addMessageHandler("simMotorStatusReport", handleMotorStatus);
-	protocol->addMessageHandler("simLimitSwitchAlert", handleLimitSwitch);
+	protocol->addMessageHandler("simLimitSwitchReport", handleLimitSwitch);
 	protocol->addMessageHandler("simRoverTruePoseReport", handleTruePose);
 	protocol->addConnectionHandler(clientConnected);
 	protocol->addDisconnectionHandler(clientDisconnected);

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -197,6 +197,7 @@ void limitSwitchPoll() {
 			}
 		}
 	}
+	guard.unlock();
 
 	// No limit switch activity delete thread and object to use less resources
 	if (limitSwitchesNotReset == 0 && watchDogPointer != nullptr) {
@@ -213,6 +214,7 @@ void handleLim(motorid_t motor, DataPoint<LimitSwitchData> limitSwitchData) {
 	std::unique_lock guard(limitSwitchMapMutex);		
 	limSwitchMap[motor].first = true;
 	limSwitchMap[motor].second = std::chrono::steady_clock::now();
+	guard.unlock();
 
 	jointid_t jointID = Constants::MOTOR_JOINT_MAP.at(motor);
 

--- a/src/world_interface/simulator_interface.cpp
+++ b/src/world_interface/simulator_interface.cpp
@@ -178,6 +178,7 @@ void limitSwitchPoll() {
 	// You must then update the mission control that the limit switch has timed out
 	// and has been reset
 	int limitSwitchesNotReset = 0;
+	std::unique_lock guard(limitSwitchMapMutex);
 	for (const auto& [key, value] : limSwitchMap) {
 		
 		// Check if the limit switch is currently being marked as active, then check if

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -8,7 +8,9 @@
 #include "../network/websocket/WebSocketServer.h"
 #include "data.h"
 #include "motor/base_motor.h"
+#include "../utils/scheduler.h"
 
+#include <chrono>
 #include <array>
 #include <optional>
 #include <unordered_set>

--- a/src/world_interface/world_interface.h
+++ b/src/world_interface/world_interface.h
@@ -227,6 +227,14 @@ void setMotorPos(robot::types::motorid_t motor, int32_t targetPos);
 void setMotorVel(robot::types::motorid_t motor, int32_t targetVel);
 
 /**
+ * @brief Sets the velocity of the given motor.
+ *
+ * @param motor The motor to set the target position of.
+ * @param targetVel The target velocity, in millidegrees per second.
+ */
+bool getMotorLimStatus(robot::types::motorid_t motor);
+
+/**
  * @brief Get the last reported position of the specified motor.
  *
  * @param motor The motor to get the position from.


### PR DESCRIPTION
Added limit switch CAN packet handling preventing further motor movements when triggered and updating both logs and sending limit switch data to mission control.